### PR TITLE
script to "reup" testnet gravity nodes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 */node_modules
+*/target/*
 .DS_Store
 .dockerignore
-.gitignore
 .git
-target
+.gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,6 @@ services:
       dockerfile: ./Dockerfile
     depends_on:
       - ethereum
-      - gravity0
     environment:
       - COSMOS_KEY
       - COSMOS_PHRASE
@@ -55,7 +54,6 @@ services:
       - ./testdata/testchain/gravity1:/root/home
     depends_on:
       - ethereum
-      - gravity0
 
   orchestrator1:
     build:
@@ -63,7 +61,6 @@ services:
       dockerfile: ./Dockerfile
     depends_on:
       - ethereum
-      - gravity1
     environment:
       - COSMOS_KEY
       - COSMOS_PHRASE
@@ -81,7 +78,6 @@ services:
       - ./testdata/testchain/gravity2:/root/home
     depends_on:
       - ethereum
-      - gravity0
 
   orchestrator2:
     build:
@@ -89,7 +85,6 @@ services:
       dockerfile: ./Dockerfile
     depends_on:
       - ethereum
-      - gravity2
     environment:
       - COSMOS_KEY
       - COSMOS_PHRASE
@@ -107,7 +102,6 @@ services:
       - ./testdata/testchain/gravity3:/root/home
     depends_on:
       - ethereum
-      - gravity0
 
   orchestrator3:
     build:
@@ -115,7 +109,6 @@ services:
       dockerfile: ./Dockerfile
     depends_on:
       - ethereum
-      - gravity3
     environment:
       - COSMOS_KEY
       - COSMOS_PHRASE
@@ -130,7 +123,6 @@ services:
       context: ./orchestrator
       dockerfile: testnet.Dockerfile
     depends_on:
-      - gravity0
       - ethereum
     volumes:
       - ./testdata:/testdata

--- a/module/Dockerfile
+++ b/module/Dockerfile
@@ -19,6 +19,11 @@ RUN apk add --no-cache $PACKAGES
 # Set working directory for the build
 WORKDIR /go/src/github.com/althea-net/cosmos-gravity-bridge/module
 
+# Get dependancies - will also be cached if we won't change mod/sum
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
 # Add source files
 COPY . .
 

--- a/testnet/reup-gravity.sh
+++ b/testnet/reup-gravity.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+
+# Constants
+PROJECT_DIR="$(dirname $SCRIPT_DIR)"
+CHAINID="testchain"
+CHAINDIR="$PROJECT_DIR/testdata"
+gravity=gravity
+home_dir="$CHAINDIR/$CHAINID"
+
+n0name="gravity0"
+n1name="gravity1"
+n2name="gravity2"
+n3name="gravity3"
+
+# Folders for nodes
+n0dir="$home_dir/$n0name"
+n1dir="$home_dir/$n1name"
+n2dir="$home_dir/$n2name"
+n3dir="$home_dir/$n3name"
+
+echo "Removing validators"
+docker-compose rm --force --stop gravity{0..3}
+
+echo "Building validators"
+docker-compose build gravity{0..3}
+
+echo "Deploying validators"
+docker-compose up --no-start gravity{0..3}
+docker-compose start gravity{0..3}

--- a/testnet/start.sh
+++ b/testnet/start.sh
@@ -214,7 +214,7 @@ chmod +x $home_dir/*/startup.sh
 echo "Building ethereum and validator images"
 docker-compose build ethereum $n0name $n1name $n2name $n3name
 
-echo "Starting testnet"
+echo "Starting ethereum and validators"
 docker-compose up --no-start ethereum $n0name $n1name $n2name $n3name &>/dev/null
 docker-compose start ethereum $n0name $n1name $n2name $n3name &>/dev/null
 
@@ -229,7 +229,6 @@ if [[ ! $contractAddress ]]; then
   exit 1
 fi
 echo "Contract address: $contractAddress"
-
 docker-compose logs --no-color --no-log-prefix contract_deployer > $CHAINDIR/contracts
 
 echo "Gathering keys for orchestrators"


### PR DESCRIPTION
Introduced `./testnet/reup-gravity.sh` to stop, build and start gravity nodes in the testnet to improve debug cycles.
Required loosening declared start-up dependencies w/in the docker-compose file; so I confirmed that our start script brings everything up from scratch still.

Also improved `module/Dockerfile` to cache go deps more effectively, so we don't download them everytime.