### PR TITLE
VALSET_STRESS end-to-end test fixes

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,42 +12,53 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run all up happy-path test
-        run: tests/all-up-test.sh
+        run: testnet/start.sh
   validator-out:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Run all up test with a validator out
-        run: tests/all-up-test.sh VALIDATOR_OUT
+        run: testnet/start.sh
+        env:
+          TEST_TYPE: VALIDATOR_OUT
   valset-stress:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Run all up valset stress test
-        run: tests/all-up-test.sh VALSET_STRESS
+        run: testnet/start.sh
+        env:
+          TEST_TYPE: VALSET_STRESS
   batch-stress:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Run all up batch stress test
-        run: tests/all-up-test.sh BATCH_STRESS
+        run: testnet/start.sh
+        env:
+          TEST_TYPE: BATCH_STRESS
   v2-happy-path:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Run all up batch stress test
-        run: tests/all-up-test.sh V2_HAPPY_PATH
+        run: testnet/start.sh
+        env:
+          TEST_TYPE: V2_HAPPY_PATH
   arbitrary-logic:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Run all up arbitrary logic test
-        run: tests/all-up-test.sh ARBITRARY_LOGIC $ALCHEMY_ID
+        run: testnet/start.sh
         env:
+          TEST_TYPE: ARBITRARY_LOGIC
           ALCHEMY_ID: ${{ secrets.ALCHEMY_ID }}
   orchestrator-keys:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Run all up arbitrary logic test
-        run: tests/all-up-test.sh ORCHESTRATOR_KEYS
+        run: testnet/start.sh
+        env:
+          TEST_TYPE: ORCHESTRATOR_KEYS

--- a/module/proto/gravity/v1/query.proto
+++ b/module/proto/gravity/v1/query.proto
@@ -19,8 +19,6 @@ service Query {
     // option (google.api.http).get = "/gravity/v1/params";
   }
 
-  // TODO(levi) ensure routes are REST-ish:
-
   // get info on individual outgoing data
   rpc SignerSetTx(SignerSetTxRequest) returns (SignerSetTxResponse) {
     // option (google.api.http).get = "/gravity/v1/signer_set";
@@ -43,12 +41,10 @@ service Query {
   }
   rpc BatchTxs(BatchTxsRequest) returns (BatchTxsResponse) {
     // option (google.api.http).get = "/gravity/v1/batch/batch_txs";
-    // TODO(levi) propose:         "/gravity/v1/batch_txs";
   }
   rpc ContractCallTxs(ContractCallTxsRequest)
       returns (ContractCallTxsResponse) {
     // option (google.api.http).get = "/gravity/v1/batch/contract_call_txs";
-    // TODO(levi) propose:         "/gravity/v1/contract_call_txs";
   }
 
   // ethereum signature queries so validators can construct valid etherum

--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -67,7 +67,8 @@ func createSignerSetTxs(ctx sdk.Context, k keeper.Keeper) {
 	blockHeight := uint64(ctx.BlockHeight())
 	powerDiff := types.EthereumSigners(k.CurrentSignerSet(ctx)).PowerDiff(latestSignerSetTx.Signers)
 
-	createSignerSetTx := (lastUnbondingHeight == blockHeight) || (powerDiff > 0.05)
+	// TODO(levi) restore this!!!: createSignerSetTx := (lastUnbondingHeight == blockHeight) || (powerDiff > 0.05)
+	createSignerSetTx := (lastUnbondingHeight == blockHeight) || (powerDiff > 0.045) // XXX(levi) deleteme and restore the prior line! this is just for debugging
 
 	ctx.Logger().Info("signerset creation",
 		"blockHeight", blockHeight,

--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -67,18 +67,16 @@ func createSignerSetTxs(ctx sdk.Context, k keeper.Keeper) {
 	blockHeight := uint64(ctx.BlockHeight())
 	powerDiff := types.EthereumSigners(k.CurrentSignerSet(ctx)).PowerDiff(latestSignerSetTx.Signers)
 
-	// TODO(levi) restore this!!!: createSignerSetTx := (lastUnbondingHeight == blockHeight) || (powerDiff > 0.05)
-	shouldCreateSignerSetTx := (lastUnbondingHeight == blockHeight) || (powerDiff > 0.02) // XXX(levi) deleteme and restore the prior line! this is just for debugging
-
-	ctx.Logger().Info("Maybe CreateSignerSetTx",
+	shouldCreate := (lastUnbondingHeight == blockHeight) || (powerDiff > 0.05)
+	ctx.Logger().Info("considering signer set tx creation",
 		"blockHeight", blockHeight,
 		"lastUnbondingHeight", lastUnbondingHeight,
 		"latestSignerSetTx.Nonce", latestSignerSetTx.Nonce,
 		"powerDiff", powerDiff,
-		"shouldCreateSignerSetTx", shouldCreateSignerSetTx,
+		"shouldCreate", shouldCreate,
 	)
 
-	if shouldCreateSignerSetTx {
+	if shouldCreate {
 		k.CreateSignerSetTx(ctx)
 	}
 }

--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -68,15 +68,17 @@ func createSignerSetTxs(ctx sdk.Context, k keeper.Keeper) {
 	powerDiff := types.EthereumSigners(k.CurrentSignerSet(ctx)).PowerDiff(latestSignerSetTx.Signers)
 
 	// TODO(levi) restore this!!!: createSignerSetTx := (lastUnbondingHeight == blockHeight) || (powerDiff > 0.05)
-	createSignerSetTx := (lastUnbondingHeight == blockHeight) || (powerDiff > 0.045) // XXX(levi) deleteme and restore the prior line! this is just for debugging
+	shouldCreateSignerSetTx := (lastUnbondingHeight == blockHeight) || (powerDiff > 0.02) // XXX(levi) deleteme and restore the prior line! this is just for debugging
 
-	ctx.Logger().Info("signerset creation",
+	ctx.Logger().Info("Maybe CreateSignerSetTx",
 		"blockHeight", blockHeight,
-		"createSignerSetTx", createSignerSetTx,
 		"lastUnbondingHeight", lastUnbondingHeight,
+		"latestSignerSetTx.Nonce", latestSignerSetTx.Nonce,
 		"powerDiff", powerDiff,
+		"shouldCreateSignerSetTx", shouldCreateSignerSetTx,
 	)
-	if createSignerSetTx {
+
+	if shouldCreateSignerSetTx {
 		k.CreateSignerSetTx(ctx)
 	}
 }

--- a/module/x/gravity/types/types_test.go
+++ b/module/x/gravity/types/types_test.go
@@ -37,7 +37,7 @@ func TestValsetConfirmHash(t *testing.T) {
 	assert.Equal(t, correctHash, hexHash)
 }
 
-func TestValsetPowerDiff(t *testing.T) {
+func TestEthereumSigners_PowerDiff(t *testing.T) {
 	specs := map[string]struct {
 		start EthereumSigners
 		diff  EthereumSigners

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
  "actix-rt 2.2.0",
  "clarity",
  "cosmos_gravity",
- "deep_space 2.1.1",
+ "deep_space 2.4.3",
  "docopt",
  "env_logger",
  "ethereum_gravity",
@@ -920,7 +920,7 @@ dependencies = [
  "bytes 1.0.1",
  "clarity",
  "cosmos-sdk-proto",
- "deep_space 2.1.1",
+ "deep_space 2.4.3",
  "env_logger",
  "ethereum_gravity",
  "gravity_proto",
@@ -984,6 +984,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "darling"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,7 +1036,7 @@ checksum = "afd044e670beb23ce6a2007d139ed3787b99c85b5ff3982b8fdfda66c3682e53"
 dependencies = [
  "base64",
  "bech32 0.7.3",
- "hmac",
+ "hmac 0.10.1",
  "num-bigint 0.3.2",
  "num-traits",
  "num256",
@@ -1043,20 +1053,20 @@ dependencies = [
 
 [[package]]
 name = "deep_space"
-version = "2.1.1"
+version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50a94e36b05397eb6843b899d8d710d262ffc34d5a226f43b15dd36398648a0"
+checksum = "ea6a81d9084ce357c7f6b07c2819f257846839fa76b209a3c89e9022c65be19b"
 dependencies = [
  "base64",
  "bech32 0.8.0",
  "bytes 1.0.1",
  "cosmos-sdk-proto",
- "hmac",
+ "hmac 0.11.0",
  "log",
  "num-bigint 0.4.0",
  "num-traits",
  "num256",
- "pbkdf2 0.7.5",
+ "pbkdf2 0.8.0",
  "prost",
  "prost-types",
  "rand 0.8.3",
@@ -1167,7 +1177,7 @@ name = "ethereum_gravity"
 version = "0.1.0"
 dependencies = [
  "clarity",
- "deep_space 2.1.1",
+ "deep_space 2.4.3",
  "gravity_utils",
  "log",
  "num256",
@@ -1410,7 +1420,7 @@ dependencies = [
  "actix-rt 2.2.0",
  "clarity",
  "cosmos_gravity",
- "deep_space 2.1.1",
+ "deep_space 2.4.3",
  "ethereum_gravity",
  "gravity_proto",
  "gravity_utils",
@@ -1441,7 +1451,7 @@ dependencies = [
  "actix",
  "clarity",
  "cosmos-sdk-proto",
- "deep_space 2.1.1",
+ "deep_space 2.4.3",
  "gravity_proto",
  "log",
  "num-bigint 0.4.0",
@@ -1545,7 +1555,17 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.10.0",
+ "digest",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac 0.11.0",
  "digest",
 ]
 
@@ -2158,7 +2178,7 @@ dependencies = [
  "actix-rt 2.2.0",
  "clarity",
  "cosmos_gravity",
- "deep_space 2.1.1",
+ "deep_space 2.4.3",
  "docopt",
  "env_logger",
  "ethereum_gravity",
@@ -2213,12 +2233,13 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85d8faea6c018131952a192ee55bd9394c51fc6f63294b668d97636e6f842d40"
+checksum = "c1a5d4e9c205d2c1ae73b84aab6240e98218c0e72e63b50422cfb2d1ca952282"
 dependencies = [
  "base64ct",
  "rand_core 0.6.2",
+ "subtle",
 ]
 
 [[package]]
@@ -2228,8 +2249,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3b8c0d71734018084da0c0354193a5edfb81b20d2d57a92c5b154aefc554a4a"
 dependencies = [
  "base64",
- "crypto-mac",
- "hmac",
+ "crypto-mac 0.10.0",
+ "hmac 0.10.1",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "sha2",
@@ -2238,13 +2259,13 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf916dd32dd26297907890d99dc2740e33f6bd9073965af4ccff2967962f5508"
+checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
 dependencies = [
  "base64ct",
- "crypto-mac",
- "hmac",
+ "crypto-mac 0.11.0",
+ "hmac 0.11.0",
  "password-hash",
  "sha2",
 ]
@@ -2597,7 +2618,7 @@ dependencies = [
  "clarity",
  "contact",
  "cosmos_gravity",
- "deep_space 2.1.1",
+ "deep_space 2.4.3",
  "docopt",
  "env_logger",
  "ethereum_gravity",
@@ -2620,7 +2641,7 @@ dependencies = [
  "actix-rt 2.2.0",
  "clarity",
  "cosmos_gravity",
- "deep_space 2.1.1",
+ "deep_space 2.4.3",
  "docopt",
  "env_logger",
  "ethereum_gravity",
@@ -3113,7 +3134,7 @@ dependencies = [
  "actix-web",
  "clarity",
  "cosmos_gravity",
- "deep_space 2.1.1",
+ "deep_space 2.4.3",
  "docopt",
  "env_logger",
  "ethereum_gravity",

--- a/orchestrator/ethereum_gravity/src/valset_update.rs
+++ b/orchestrator/ethereum_gravity/src/valset_update.rs
@@ -155,8 +155,11 @@ fn encode_valset_payload(
         sig_arrays.r,
         sig_arrays.s,
     ];
-    let payload = clarity::abi::encode_call("updateValset(address[],uint256[],uint256,address[],uint256[],uint256,uint8[],bytes32[],bytes32[])",
-    tokens).unwrap();
+
+    let payload = clarity::abi::encode_call(
+        "updateValset(address[],uint256[],uint256,address[],uint256[],uint256,uint8[],bytes32[],bytes32[])",
+        tokens,
+    ).unwrap();
 
     Ok(payload)
 }

--- a/orchestrator/relayer/src/main_loop.rs
+++ b/orchestrator/relayer/src/main_loop.rs
@@ -26,13 +26,13 @@ pub async fn relayer_main_loop(
         let loop_start = Instant::now();
 
         let our_ethereum_address = ethereum_key.to_public_key().unwrap();
-        let current_valset =
+        let current_eth_valset =
             find_latest_valset(&mut grpc_client, gravity_contract_address, &web3).await;
-        if current_valset.is_err() {
-            error!("Could not get current valset! {:?}", current_valset);
+        if current_eth_valset.is_err() {
+            error!("Could not get current valset! {:?}", current_eth_valset);
             continue;
         }
-        let current_valset = current_valset.unwrap();
+        let current_eth_valset = current_eth_valset.unwrap();
 
         let gravity_id =
             get_gravity_id(gravity_contract_address, our_ethereum_address, &web3).await;
@@ -44,7 +44,7 @@ pub async fn relayer_main_loop(
         let gravity_id = String::from_utf8(gravity_id.clone()).expect("Invalid GravityID");
 
         relay_valsets(
-            current_valset.clone(),
+            current_eth_valset.clone(),
             ethereum_key,
             &web3,
             &mut grpc_client,
@@ -55,7 +55,7 @@ pub async fn relayer_main_loop(
         .await;
 
         relay_batches(
-            current_valset.clone(),
+            current_eth_valset.clone(),
             ethereum_key,
             &web3,
             &mut grpc_client,
@@ -66,7 +66,7 @@ pub async fn relayer_main_loop(
         .await;
 
         relay_logic_calls(
-            current_valset,
+            current_eth_valset,
             ethereum_key,
             &web3,
             &mut grpc_client,

--- a/orchestrator/relayer/src/valset_relaying.rs
+++ b/orchestrator/relayer/src/valset_relaying.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use clarity::address::Address as EthAddress;
 use clarity::PrivateKey as EthPrivateKey;
-use cosmos_gravity::query::get_latest_valsets;
+use cosmos_gravity::query::get_latest_valset;
 use cosmos_gravity::query::{get_all_valset_confirms, get_valset};
 use ethereum_gravity::{one_eth, utils::downcast_to_u128, valset_update::send_eth_valset_update};
 use gravity_proto::gravity::query_client::QueryClient as GravityQueryClient;
@@ -17,7 +17,7 @@ use web30::client::Web3;
 /// set then we should package and submit the update as an Ethereum transaction
 pub async fn relay_valsets(
     // the validator set currently in the contract on Ethereum
-    current_valset: Valset,
+    current_eth_valset: Valset,
     ethereum_key: EthPrivateKey,
     web3: &Web3,
     grpc_client: &mut GravityQueryClient<Channel>,
@@ -25,7 +25,7 @@ pub async fn relay_valsets(
     gravity_id: String,
     timeout: Duration,
 ) {
-    // we have to start with the current valset, we need to know what's currently
+    // we have to start with the current ethereum valset, we need to know what's currently
     // in the contract in order to determine if a new validator set is valid.
     // For example the contract has set A which contains validators x/y/z the
     // latest valset has set C which has validators z/e/f in order to have enough
@@ -34,57 +34,67 @@ pub async fn relay_valsets(
 
     // we should determine if we need to relay one
     // to Ethereum for that we will find the latest confirmed valset and compare it to the ethereum chain
-    let latest_valsets = get_latest_valsets(grpc_client).await;
-    if latest_valsets.is_err() {
-        trace!("Failed to get latest valsets!");
-        // there are no latest valsets to check, possible on a bootstrapping chain maybe handle better?
+    let latest_valset = get_latest_valset(grpc_client).await;
+    if latest_valset.is_err() {
+        error!("Failed to get latest valset! {:?}", latest_valset);
         return;
     }
-    let latest_valsets = latest_valsets.unwrap();
-    if latest_valsets.is_empty() {
+    let latest_valset = latest_valset.unwrap();
+    if latest_valset.is_none() {
         return;
     }
+
+    let latest_valset = latest_valset.unwrap();
 
     // we only use the latest valsets endpoint to get a starting point, from there we will iterate
     // backwards until we find the newest validator set that we can submit to the bridge. So if we
     // have sets A-Z and it's possible to submit only A, L, and Q before reaching Z this code will do
     // so.
-    let mut latest_nonce = latest_valsets[0].nonce;
+    let mut latest_nonce = latest_valset.nonce;
     let mut latest_confirmed = None;
-    let mut latest_valset = None;
+    let mut latest_cosmos_valset = None;
     // this is used to display the state of the last validator set to fail signature checks
     let mut last_error = None;
     while latest_nonce > 0 {
-        let valset = get_valset(grpc_client, latest_nonce).await;
-        if let Ok(Some(valset)) = valset {
-            assert_eq!(valset.nonce, latest_nonce);
+        let cosmos_valset = get_valset(grpc_client, latest_nonce).await;
+        if let Ok(Some(cosmos_valset)) = cosmos_valset {
+            assert_eq!(cosmos_valset.nonce, latest_nonce);
             let confirms = get_all_valset_confirms(grpc_client, latest_nonce).await;
             if let Ok(confirms) = confirms {
+                info!(
+                    "Considering cosmos_valset {:?} confirms {:?}",
+                    cosmos_valset, confirms
+                );
+
                 for confirm in confirms.iter() {
-                    assert_eq!(valset.nonce, confirm.nonce);
+                    assert_eq!(cosmos_valset.nonce, confirm.nonce);
                 }
-                let hash = encode_valset_confirm_hashed(gravity_id.clone(), valset.clone());
+                let hash = encode_valset_confirm_hashed(gravity_id.clone(), cosmos_valset.clone());
                 // order valset sigs prepares signatures for submission, notice we compare
                 // them to the 'current' set in the bridge, this confirms for us that the validator set
                 // we have here can be submitted to the bridge in it's current state
-                let res = current_valset.order_sigs(&hash, &confirms);
+                let res = current_eth_valset.order_sigs(&hash, &confirms);
                 if res.is_ok() {
+                    info!("Consideration: looks good");
                     latest_confirmed = Some(confirms);
-                    latest_valset = Some(valset);
+                    latest_cosmos_valset = Some(cosmos_valset);
                     // once we have the latest validator set we can submit exit
                     break;
                 } else if let Err(e) = res {
+                    info!("Consideration: looks bad {}", e);
                     last_error = Some(e);
-                    // TODO(levi) break or return??
                 }
             }
-            // TODO(levi) this isn't handling errors
+            // TODO(levi) this is ignoring/swallowing errors
         }
-        // TODO(levi) this isn't handling errors
+        // TODO(levi) this is ignoring/swallowing errors
 
         latest_nonce -= 1
     }
-    // TODO(levi) this isn't handling errors
+    // TODO(levi) this is ignoring/swallowing errors
+
+    info!("Relaying latest_confirmed {:?}", latest_confirmed);
+    info!("Relaying latest_cosmos_valset {:?}", latest_cosmos_valset);
 
     if latest_confirmed.is_none() {
         error!("We don't have a latest confirmed valset?");
@@ -92,7 +102,7 @@ pub async fn relay_valsets(
     }
     // the latest cosmos validator set that it is possible to submit given the constraints
     // of the validator set currently in the bridge
-    let latest_cosmos_valset = latest_valset.unwrap();
+    let latest_cosmos_valset = latest_cosmos_valset.unwrap();
     // the signatures for the above
     let latest_cosmos_confirmed = latest_confirmed.unwrap();
 
@@ -103,11 +113,17 @@ pub async fn relay_valsets(
         warn!("{:?}", last_error)
     }
 
-    let latest_cosmos_valset_nonce = latest_cosmos_valset.nonce;
-    if latest_cosmos_valset_nonce > current_valset.nonce {
+    let should_relay = latest_cosmos_valset.nonce > current_eth_valset.nonce;
+    info!(
+        "Considering nonces: latest_cosmos_valset.nonce {} current_eth_valset.nonce {} should_relay {}",
+        latest_cosmos_valset.nonce, current_eth_valset.nonce,
+        should_relay,
+    );
+
+    if should_relay {
         let cost = ethereum_gravity::valset_update::estimate_valset_cost(
             &latest_cosmos_valset,
-            &current_valset,
+            &current_eth_valset,
             &latest_cosmos_confirmed,
             web3,
             gravity_contract_address,
@@ -126,15 +142,15 @@ pub async fn relay_valsets(
 
         info!(
            "We have detected latest valset {} but latest on Ethereum is {} This valset is estimated to cost {} Gas / {:.4} ETH to submit",
-            latest_cosmos_valset.nonce, current_valset.nonce,
+            latest_cosmos_valset.nonce, current_eth_valset.nonce,
             cost.gas_price.clone(),
             downcast_to_u128(cost.get_total()).unwrap() as f32
                 / downcast_to_u128(one_eth()).unwrap() as f32
         );
 
-        let _res = send_eth_valset_update(
-            latest_cosmos_valset,
-            current_valset,
+        let relay_response = send_eth_valset_update(
+            latest_cosmos_valset.clone(),
+            current_eth_valset.clone(),
             &latest_cosmos_confirmed,
             web3,
             timeout,
@@ -143,5 +159,10 @@ pub async fn relay_valsets(
             ethereum_key,
         )
         .await;
+
+        info!(
+            "relay_response {:?} (latest_cosmos_valset.nonce {} current_eth_valset.nonce {})",
+            relay_response, latest_cosmos_valset.nonce, current_eth_valset.nonce,
+        );
     }
 }

--- a/orchestrator/test_runner/Cargo.toml
+++ b/orchestrator/test_runner/Cargo.toml
@@ -16,7 +16,7 @@ gravity_utils = {path = "../gravity_utils"}
 gravity_proto = {path = "../gravity_proto/"}
 orchestrator = {path = "../orchestrator/"}
 
-deep_space = "2.1"
+deep_space = "2.4.3"
 serde_derive = "1.0"
 clarity = "0.4"
 docopt = "1"

--- a/orchestrator/test_runner/src/happy_path.rs
+++ b/orchestrator/test_runner/src/happy_path.rs
@@ -162,8 +162,8 @@ pub async fn test_valset_update(
         .to_string();
 
     // should be about 4% of the total power to start
-    // let amount = crate::STAKE_SUPPLY_PER_VALIDATOR / 4; // 25B
-    let amount = crate::STARTING_STAKE_PER_VALIDATOR / 4; // 12.5B
+    // let amount = crate::STARTING_STAKE_PER_VALIDATOR / 4; // 12.5B
+    let amount = crate::STAKE_SUPPLY_PER_VALIDATOR / 4; // 25B
     let amount = deep_space::Coin {
         amount: amount.into(),
         denom: "stake".to_string(),

--- a/orchestrator/test_runner/src/happy_path.rs
+++ b/orchestrator/test_runner/src/happy_path.rs
@@ -4,7 +4,6 @@ use crate::utils::*;
 use crate::MINER_ADDRESS;
 use crate::MINER_PRIVATE_KEY;
 use crate::OPERATION_TIMEOUT;
-use crate::STARTING_STAKE_PER_VALIDATOR;
 use crate::TOTAL_TIMEOUT;
 use clarity::PrivateKey as EthPrivateKey;
 use clarity::{Address as EthAddress, Uint256};
@@ -163,8 +162,10 @@ pub async fn test_valset_update(
         .to_string();
 
     // should be about 4% of the total power to start
+    // let amount = crate::STAKE_SUPPLY_PER_VALIDATOR / 4; // 25B
+    let amount = crate::STARTING_STAKE_PER_VALIDATOR / 4; // 12.5B
     let amount = deep_space::Coin {
-        amount: (STARTING_STAKE_PER_VALIDATOR / 4).into(),
+        amount: amount.into(),
         denom: "stake".to_string(),
     };
     info!(

--- a/orchestrator/test_runner/src/happy_path.rs
+++ b/orchestrator/test_runner/src/happy_path.rs
@@ -192,8 +192,6 @@ pub async fn test_valset_update(
             continue; // retry
         }
 
-        // TODO(levi) consider contact.wait_for_tx(res, OPERATION_TIMEOUT) here
-
         info!("Delegated {} to {}", amount, delegate_address);
         break;
     }

--- a/orchestrator/test_runner/src/happy_path.rs
+++ b/orchestrator/test_runner/src/happy_path.rs
@@ -156,19 +156,18 @@ pub async fn test_valset_update(
     // makes any difference, eventually it will fail because the change to the total staked
     // percentage is too small.
     let mut rng = rand::thread_rng();
-    let validator_to_change = rng.gen_range(0..keys.len());
-    let validator_to_change = keys[validator_to_change].validator_key;
+    let keys_to_change = rng.gen_range(0..keys.len());
+    let keys_to_change = &keys[keys_to_change];
+
+    let validator_to_change = keys_to_change.validator_key;
     let delegate_address = validator_to_change
         .to_address("cosmosvaloper")
         .unwrap()
         .to_string();
+
     // should be about 4% of the total power to start
     let amount = deep_space::Coin {
         amount: (STARTING_STAKE_PER_VALIDATOR / 4).into(),
-        denom: "stake".to_string(),
-    };
-    let fee = deep_space::Coin {
-        amount: 125000000u32.into(),
         denom: "stake".to_string(),
     };
     info!(
@@ -180,8 +179,8 @@ pub async fn test_valset_update(
         .delegate_to_validator(
             delegate_address.parse().unwrap(),
             amount.clone(),
-            fee,
-            validator_to_change,
+            get_fee(),
+            keys_to_change.orch_key,
             Some(OPERATION_TIMEOUT),
         )
         .await

--- a/orchestrator/test_runner/src/happy_path.rs
+++ b/orchestrator/test_runner/src/happy_path.rs
@@ -32,7 +32,7 @@ pub async fn happy_path_test(
     keys: Vec<ValidatorKeys>,
     gravity_address: EthAddress,
     erc20_address: EthAddress,
-    _validator_out: bool,
+    validator_out: bool,
 ) {
     let mut grpc_client = grpc_client;
 
@@ -47,19 +47,13 @@ pub async fn happy_path_test(
     // working. We'll settle for testing that the initial valset (generated
     // with the first block) is successfully updated
 
-    // TODO JEHAN: bring this back in once we have a gRPC library for delegating
-    // if !validator_out {
-    //     for _ in 0u32..2 {
-    //         test_valset_update(&web30, &keys, gravity_address).await;
-    //     }
-    // } else {
-    //     wait_for_nonzero_valset(&web30, gravity_address).await;
-    // }
-
-    // TODO JEHAN: take this out once the above has been brought back in
-    wait_for_nonzero_valset(&web30, gravity_address).await;
-
-    println!(":==: got past wait_for_nonzero_valset");
+    if !validator_out {
+        for _ in 0u32..2 {
+            test_valset_update(&web30, contact, &keys, gravity_address).await;
+        }
+    } else {
+        wait_for_nonzero_valset(&web30, gravity_address).await;
+    }
 
     // generate an address for coin sending tests, this ensures test imdepotency
     let mut rng = rand::thread_rng();
@@ -147,7 +141,10 @@ pub async fn test_valset_update(
 
     // now we send a valset request that the orchestrators will pick up on
     // in this case we send it as the first validator because they can pay the fee
-    info!("Sending in valset request");
+    info!(
+        "Sending in valset request (starting_eth_valset_nonce {})",
+        starting_eth_valset_nonce
+    );
 
     // this is hacky and not really a good way to test validator set updates in a highly
     // repeatable fashion. What we really need to do is be aware of the total staking state

--- a/orchestrator/test_runner/src/happy_path.rs
+++ b/orchestrator/test_runner/src/happy_path.rs
@@ -162,23 +162,25 @@ pub async fn test_valset_update(
         .to_address("cosmosvaloper")
         .unwrap()
         .to_string();
-
     // should be about 4% of the total power to start
     let amount = deep_space::Coin {
         amount: (STARTING_STAKE_PER_VALIDATOR / 4).into(),
         denom: "stake".to_string(),
     };
-
+    let fee = deep_space::Coin {
+        amount: 125000000u32.into(),
+        denom: "stake".to_string(),
+    };
     info!(
         "Delegating {} to {} in order to generate a validator set update",
         amount, delegate_address
     );
 
-    let delres = contact
+    let del_tx = contact
         .delegate_to_validator(
             delegate_address.parse().unwrap(),
             amount.clone(),
-            get_fee(),
+            fee,
             validator_to_change,
             Some(OPERATION_TIMEOUT),
         )
@@ -186,8 +188,8 @@ pub async fn test_valset_update(
         .expect("Failed to delegate");
 
     info!(
-        "Delegated {} to {} delres {:?}",
-        amount, delegate_address, delres
+        "Delegated {} to {} del_tx {:?}",
+        amount, delegate_address, del_tx
     );
 
     let mut current_eth_valset_nonce = get_valset_nonce(gravity_address, *MINER_ADDRESS, &web30)

--- a/orchestrator/test_runner/src/happy_path_v2.rs
+++ b/orchestrator/test_runner/src/happy_path_v2.rs
@@ -109,7 +109,7 @@ pub async fn happy_path_test_v2(
     contact
         .send_tokens(
             send_to_user_coin.clone(),
-            get_fee(),
+            Some(get_fee()),
             user.cosmos_address,
             keys[0].validator_key,
             Some(TOTAL_TIMEOUT),

--- a/orchestrator/test_runner/src/main.rs
+++ b/orchestrator/test_runner/src/main.rs
@@ -175,6 +175,7 @@ pub async fn main() {
             .await;
             return;
         } else if test_type == "BATCH_STRESS" {
+            info!("Starting batch stress test");
             let contact = Contact::new(
                 COSMOS_NODE_GRPC.as_str(),
                 TOTAL_TIMEOUT,
@@ -184,7 +185,7 @@ pub async fn main() {
             transaction_stress_test(&web30, &contact, keys, gravity_address, erc20_addresses).await;
             return;
         } else if test_type == "VALSET_STRESS" {
-            info!("Starting Valset update stress test");
+            info!("Starting valset stress test");
             validator_set_stress_test(&web30, &contact, keys, gravity_address).await;
             return;
         } else if test_type == "V2_HAPPY_PATH" {

--- a/orchestrator/test_runner/src/main.rs
+++ b/orchestrator/test_runner/src/main.rs
@@ -51,9 +51,9 @@ lazy_static! {
 /// this value reflects the contents of /tests/container-scripts/setup-validator.sh
 /// and is used to compute if a stake change is big enough to trigger a validator set
 /// update since we want to make several such changes intentionally
-pub const STAKE_SUPPLY_PER_VALIDATOR: u128 = 100_000_000_000;
+pub const STAKE_SUPPLY_PER_VALIDATOR: u128 = 100000000000; // 100B
 /// this is the amount each validator bonds at startup
-pub const STARTING_STAKE_PER_VALIDATOR: u128 = STAKE_SUPPLY_PER_VALIDATOR / 2;
+pub const STARTING_STAKE_PER_VALIDATOR: u128 = STAKE_SUPPLY_PER_VALIDATOR / 2; // 50B
 
 lazy_static! {
     // this key is the private key for the public key defined in tests/assets/ETHGenesis.json

--- a/orchestrator/test_runner/src/main.rs
+++ b/orchestrator/test_runner/src/main.rs
@@ -51,7 +51,7 @@ lazy_static! {
 /// this value reflects the contents of /tests/container-scripts/setup-validator.sh
 /// and is used to compute if a stake change is big enough to trigger a validator set
 /// update since we want to make several such changes intentionally
-pub const STAKE_SUPPLY_PER_VALIDATOR: u128 = 1000000000;
+pub const STAKE_SUPPLY_PER_VALIDATOR: u128 = 100_000_000_000;
 /// this is the amount each validator bonds at startup
 pub const STARTING_STAKE_PER_VALIDATOR: u128 = STAKE_SUPPLY_PER_VALIDATOR / 2;
 

--- a/orchestrator/test_runner/src/valset_stress.rs
+++ b/orchestrator/test_runner/src/valset_stress.rs
@@ -6,11 +6,11 @@ use web30::client::Web3;
 
 pub async fn validator_set_stress_test(
     web30: &Web3,
-    _contact: &Contact,
+    contact: &Contact,
     keys: Vec<ValidatorKeys>,
     gravity_address: EthAddress,
 ) {
     for _ in 0u32..10 {
-        test_valset_update(&web30, &keys, gravity_address).await;
+        test_valset_update(&web30, contact, &keys, gravity_address).await;
     }
 }

--- a/testnet/start.sh
+++ b/testnet/start.sh
@@ -85,13 +85,9 @@ find $home_dir -name validator_key.json | xargs cat | jq -r '.mnemonic' > $CHAIN
 
 echo "Adding validator addresses to genesis files"
 $gravity $home0 add-genesis-account $($gravity $home0 keys show val -a $kbt) $coins &>/dev/null
-#$gravity $home0 add-genesis-account $($FED $home0 keys show feeder) $coins &>/dev/null
 $gravity $home0 add-genesis-account $($gravity $home1 keys show val -a $kbt) $coins &>/dev/null
-#$gravity $home0 add-genesis-account $($FED $home1 keys show feeder) $coins &>/dev/null
 $gravity $home0 add-genesis-account $($gravity $home2 keys show val -a $kbt) $coins &>/dev/null
-#$gravity $home0 add-genesis-account $($FED $home2 keys show feeder) $coins &>/dev/null
 $gravity $home0 add-genesis-account $($gravity $home3 keys show val -a $kbt) $coins &>/dev/null
-#$gravity $home0 add-genesis-account $($FED $home3 keys show feeder) $coins &>/dev/null
 
 echo "Generating orchestrator keys"
 $gravity $home0 keys add --dry-run=true --output=json orch | jq . >> $n0dir/orchestrator_key.json


### PR DESCRIPTION
This PR stabilizes the VALSET_STRESS end-to-end test. 

These tests are not yet runnable via GitHub actions / CI. 

To run them manually, the current practice is:

```bash
$ pushd module/ && make install && popd # to ensure you have an up-to-date `gravity` binary
$ docker-compose down && sudo rm -fr testdata && TEST_TYPE=VALSET_STRESS ./start-testnet.sh # to ensure a pristine test-run
```