### PR TITLE
Fix "Validator signature does not match." errors

### DIFF
--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -804,12 +804,12 @@ dependencies = [
 
 [[package]]
 name = "clarity"
-version = "0.4.5"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6e4fd4d89ab771e35070d5a4233f944e7769f44e99ce2c4ea565bd29ac4a6d"
+checksum = "f9a71f164b576fc638513be84beb1b2173a18ce1639d2ac9c9054e46f361e4e0"
 dependencies = [
  "lazy_static",
- "num-bigint 0.3.2",
+ "num-bigint 0.4.0",
  "num-traits",
  "num256",
  "secp256k1 0.20.1",
@@ -1988,7 +1988,6 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -2000,6 +1999,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/orchestrator/gravity_utils/src/types/signatures.rs
+++ b/orchestrator/gravity_utils/src/types/signatures.rs
@@ -62,15 +62,15 @@ pub fn to_arrays(input: Vec<GravitySignature>) -> GravitySignatureArrays {
         addresses.push(val.eth_address);
         powers.push(val.power);
         v.push(val.v);
-        r.push(Token::Bytes(val.r.to_bytes_be()));
-        s.push(Token::Bytes(val.s.to_bytes_be()));
+        r.push(val.r);
+        s.push(val.s);
     }
     GravitySignatureArrays {
         addresses,
         powers,
         v: v.into(),
-        r: Token::Dynamic(r),
-        s: Token::Dynamic(s),
+        r: r.into(),
+        s: s.into(),
     }
 }
 


### PR DESCRIPTION
This started as an optimistic clarity upgrade
-version = "0.4.5"
+version = "0.4.10"

Then cherry-picked this deep-fix from Justin:
https://github.com/althea-net/cosmos-gravity-bridge/commit/d752ed0639bdbb61641599f7afa091a0046731e3