### PR TITLE
fix non contiguous event nonce errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - DENOM
       - ETH_PRIVATE_KEY
       - RUST_BACKTRACE=1
-      - RUST_LOG=INFO
+      - RUST_LOG
       - VALIDATOR
 
   gravity1:
@@ -126,5 +126,5 @@ services:
       - ./testdata:/testdata
     environment:
       - RUST_BACKTRACE=1
-      - RUST_LOG=INFO
+      - RUST_LOG
       - TEST_TYPE

--- a/orchestrator/gravity_utils/src/types/ethereum_events.rs
+++ b/orchestrator/gravity_utils/src/types/ethereum_events.rs
@@ -139,6 +139,17 @@ impl ValsetUpdatedEvent {
         }
         Ok(res)
     }
+    /// returns all values in the array with event nonces greater
+    /// than the provided value
+    pub fn filter_by_event_nonce(event_nonce: u64, input: &[Self]) -> Vec<Self> {
+        let mut ret = Vec::new();
+        for item in input {
+            if item.event_nonce > event_nonce.into() {
+                ret.push(item.clone())
+            }
+        }
+        ret
+    }
 }
 
 /// A parsed struct representing the Ethereum event fired by the Gravity contract when

--- a/testnet/start.sh
+++ b/testnet/start.sh
@@ -215,8 +215,8 @@ echo "Building ethereum and validator images"
 docker-compose build ethereum $n0name $n1name $n2name $n3name
 
 echo "Starting ethereum and validators"
-docker-compose up --no-start ethereum $n0name $n1name $n2name $n3name &>/dev/null
-docker-compose start ethereum $n0name $n1name $n2name $n3name &>/dev/null
+docker-compose up --no-start ethereum $n0name $n1name $n2name $n3name
+docker-compose start ethereum $n0name $n1name $n2name $n3name
 
 echo "Waiting for cosmos cluster to sync"
 sleep 10


### PR DESCRIPTION
Fixes for the following; which occurs intermittently, but regularly:

```
check_for_events send_ethereum_claims response TxResponse { height: 37, txhash: "D19947B0CB9A3801C458E20B60C5AC533BD115ED11C714333FDED33B6FDAB02E", codespace: "gravity", code: 3, data: "", raw_log: "failed to execute message; message index: 0: create event vote record: non contiguous event nonce expected 4 observed 3 for validator 83A7E562DF8662B1BDB47FF0E74390E7FF320CDD: invalid", logs: [], info: "", gas_wanted: 500000000, gas_used: 55933, tx: Some(Any { type_url: "/cosmos.tx.v1beta1.Tx", value: [...] }), timestamp: "2021-06-17T14:53:21Z" }
```