### PR TITLE
x/gravity: support updating delegate keys

### DIFF
--- a/module/x/gravity/handler.go
+++ b/module/x/gravity/handler.go
@@ -16,27 +16,34 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 
 	return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
 		ctx = ctx.WithEventManager(sdk.NewEventManager())
+
 		switch msg := msg.(type) {
 		case *types.MsgSendToEthereum:
 			res, err := msgServer.SendToEthereum(sdk.WrapSDKContext(ctx), msg)
 			return sdk.WrapServiceResult(ctx, res, err)
+
 		case *types.MsgCancelSendToEthereum:
 			res, err := msgServer.CancelSendToEthereum(sdk.WrapSDKContext(ctx), msg)
 			return sdk.WrapServiceResult(ctx, res, err)
+
 		case *types.MsgRequestBatchTx:
 			res, err := msgServer.RequestBatchTx(sdk.WrapSDKContext(ctx), msg)
 			return sdk.WrapServiceResult(ctx, res, err)
+
 		case *types.MsgSubmitEthereumTxConfirmation:
 			res, err := msgServer.SubmitEthereumTxConfirmation(sdk.WrapSDKContext(ctx), msg)
 			return sdk.WrapServiceResult(ctx, res, err)
+
 		case *types.MsgSubmitEthereumEvent:
 			res, err := msgServer.SubmitEthereumEvent(sdk.WrapSDKContext(ctx), msg)
 			return sdk.WrapServiceResult(ctx, res, err)
+
 		case *types.MsgDelegateKeys:
 			res, err := msgServer.SetDelegateKeys(sdk.WrapSDKContext(ctx), msg)
 			return sdk.WrapServiceResult(ctx, res, err)
+
 		default:
-			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, fmt.Sprintf("Unrecognized Gravity Msg type: %v", msg.Type()))
+			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized %s message type: %T", types.ModuleName, msg)
 		}
 	}
 }

--- a/module/x/gravity/handler.go
+++ b/module/x/gravity/handler.go
@@ -1,8 +1,6 @@
 package gravity
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 

--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -152,14 +152,30 @@ func (k Keeper) iterateEthereumSignatures(ctx sdk.Context, storeIndex []byte, cb
 //  ORC -> VAL ADDRESS //
 /////////////////////////
 
-// SetOrchestratorValidatorAddress sets the Orchestrator key for a given validator
-func (k Keeper) SetOrchestratorValidatorAddress(ctx sdk.Context, val sdk.ValAddress, orch sdk.AccAddress) {
-	ctx.KVStore(k.storeKey).Set(types.MakeOrchestratorValidatorAddressKey(orch), val.Bytes())
+// SetOrchestratorValidatorAddress sets the Orchestrator key for a given validator.
+func (k Keeper) SetOrchestratorValidatorAddress(ctx sdk.Context, val sdk.ValAddress, orchAddr sdk.AccAddress) {
+	store := ctx.KVStore(k.storeKey)
+	key := types.MakeOrchestratorValidatorAddressKey(orchAddr)
+
+	store.Set(key, val.Bytes())
 }
 
-// GetOrchestratorValidatorAddress returns the validator key associated with an orchestrator key
-func (k Keeper) GetOrchestratorValidatorAddress(ctx sdk.Context, orch sdk.AccAddress) sdk.ValAddress {
-	return sdk.ValAddress(ctx.KVStore(k.storeKey).Get(types.MakeOrchestratorValidatorAddressKey(orch)))
+// GetOrchestratorValidatorAddress returns the validator key associated with an
+// orchestrator key.
+func (k Keeper) GetOrchestratorValidatorAddress(ctx sdk.Context, orchAddr sdk.AccAddress) sdk.ValAddress {
+	store := ctx.KVStore(k.storeKey)
+	key := types.MakeOrchestratorValidatorAddressKey(orchAddr)
+
+	return sdk.ValAddress(store.Get(key))
+}
+
+// DeleteOrchestratorValidatorAddress removes a registered orchestrator key for a
+// given validator.
+func (k Keeper) DeleteOrchestratorValidatorAddress(ctx sdk.Context, orchAddr sdk.AccAddress) {
+	store := ctx.KVStore(k.storeKey)
+	key := types.MakeOrchestratorValidatorAddressKey(orchAddr)
+
+	store.Delete(key)
 }
 
 ////////////////////////
@@ -184,11 +200,11 @@ func (k Keeper) GetValidatorEthereumAddress(ctx sdk.Context, valAddr sdk.ValAddr
 
 // DeleteValidatorEthereumAddress removes a registered Ethereum address from
 // state.
-func (k Keeper) DeleteValidatorEthereumAddress(ctx sdk.Context, valAddr sdk.ValAddress) common.Address {
+func (k Keeper) DeleteValidatorEthereumAddress(ctx sdk.Context, valAddr sdk.ValAddress) {
 	store := ctx.KVStore(k.storeKey)
 	key := types.MakeValidatorEthereumAddressKey(valAddr)
 
-	return common.BytesToAddress(store.Get(key))
+	store.Delete(key)
 }
 
 func (k Keeper) getValidatorsByEthereumAddress(ctx sdk.Context, ethAddr common.Address) (vals []sdk.ValAddress) {

--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -167,13 +167,19 @@ func (k Keeper) GetOrchestratorValidatorAddress(ctx sdk.Context, orch sdk.AccAdd
 ////////////////////////
 
 // setValidatorEthereumAddress sets the ethereum address for a given validator
-func (k Keeper) setValidatorEthereumAddress(ctx sdk.Context, validator sdk.ValAddress, ethAddr common.Address) {
-	ctx.KVStore(k.storeKey).Set(types.MakeValidatorEthereumAddressKey(validator), ethAddr.Bytes())
+func (k Keeper) setValidatorEthereumAddress(ctx sdk.Context, valAddr sdk.ValAddress, ethAddr common.Address) {
+	store := ctx.KVStore(k.storeKey)
+	key := types.MakeValidatorEthereumAddressKey(valAddr)
+
+	store.Set(key, ethAddr.Bytes())
 }
 
-// GetValidatorEthereumAddress returns the eth address for a given gravity validator
-func (k Keeper) GetValidatorEthereumAddress(ctx sdk.Context, validator sdk.ValAddress) common.Address {
-	return common.BytesToAddress(ctx.KVStore(k.storeKey).Get(types.MakeValidatorEthereumAddressKey(validator)))
+// GetValidatorEthereumAddress returns the eth address for a given gravity validator.
+func (k Keeper) GetValidatorEthereumAddress(ctx sdk.Context, valAddr sdk.ValAddress) common.Address {
+	store := ctx.KVStore(k.storeKey)
+	key := types.MakeValidatorEthereumAddressKey(valAddr)
+
+	return common.BytesToAddress(store.Get(key))
 }
 
 func (k Keeper) getValidatorsByEthereumAddress(ctx sdk.Context, ethAddr common.Address) (vals []sdk.ValAddress) {
@@ -196,12 +202,27 @@ func (k Keeper) getValidatorsByEthereumAddress(ctx sdk.Context, ethAddr common.A
 
 // setEthereumOrchestratorAddress sets the eth orch addr mapping
 func (k Keeper) setEthereumOrchestratorAddress(ctx sdk.Context, ethAddr common.Address, orch sdk.AccAddress) {
-	ctx.KVStore(k.storeKey).Set(types.MakeEthereumOrchestratorAddressKey(ethAddr), orch.Bytes())
+	store := ctx.KVStore(k.storeKey)
+	key := types.MakeEthereumOrchestratorAddressKey(ethAddr)
+
+	store.Set(key, orch.Bytes())
 }
 
 // GetEthereumOrchestratorAddress gets the orch address for a given eth address
 func (k Keeper) GetEthereumOrchestratorAddress(ctx sdk.Context, ethAddr common.Address) sdk.AccAddress {
-	return sdk.AccAddress(ctx.KVStore(k.storeKey).Get(types.MakeEthereumOrchestratorAddressKey(ethAddr)))
+	store := ctx.KVStore(k.storeKey)
+	key := types.MakeEthereumOrchestratorAddressKey(ethAddr)
+
+	return sdk.AccAddress(store.Get(key))
+}
+
+// DeleteEthereumOrchestratorAddress removes a registered orchestrator address
+// from state.
+func (k Keeper) DeleteEthereumOrchestratorAddress(ctx sdk.Context, ethAddr common.Address) {
+	store := ctx.KVStore(k.storeKey)
+	key := types.MakeEthereumOrchestratorAddressKey(ethAddr)
+
+	store.Delete(key)
 }
 
 func (k Keeper) getEthereumAddressesByOrchestrator(ctx sdk.Context, orch sdk.AccAddress) (ethAddrs []common.Address) {

--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -182,6 +182,15 @@ func (k Keeper) GetValidatorEthereumAddress(ctx sdk.Context, valAddr sdk.ValAddr
 	return common.BytesToAddress(store.Get(key))
 }
 
+// DeleteValidatorEthereumAddress removes a registered Ethereum address from
+// state.
+func (k Keeper) DeleteValidatorEthereumAddress(ctx sdk.Context, valAddr sdk.ValAddress) common.Address {
+	store := ctx.KVStore(k.storeKey)
+	key := types.MakeValidatorEthereumAddressKey(valAddr)
+
+	return common.BytesToAddress(store.Get(key))
+}
+
 func (k Keeper) getValidatorsByEthereumAddress(ctx sdk.Context, ethAddr common.Address) (vals []sdk.ValAddress) {
 	iter := ctx.KVStore(k.storeKey).Iterator(nil, nil)
 

--- a/module/x/gravity/keeper/msg_server.go
+++ b/module/x/gravity/keeper/msg_server.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -54,16 +55,17 @@ func (k msgServer) SetDelegateKeys(c context.Context, msg *types.MsgDelegateKeys
 	//
 	// Otherwise, we treat the validator as it is setting their delegate keys for
 	// the first time and only erroring if either of the keys exist.
+	var emptyEthAddr common.Address
 
 	currEthAddr := k.GetValidatorEthereumAddress(ctx, valAddr)
-	if len(currEthAddr) > 0 {
+	if !bytes.Equal(emptyEthAddr.Bytes(), currEthAddr.Bytes()) {
 		k.DeleteValidatorEthereumAddress(ctx, valAddr)
 	}
 
 	// check if the Ethereum address is currently not used
 	validators := k.getValidatorsByEthereumAddress(ctx, ethAddr)
 	if len(validators) > 0 {
-		if len(currEthAddr) > 0 {
+		if !bytes.Equal(emptyEthAddr.Bytes(), currEthAddr.Bytes()) {
 			// reset to the original value in case of failure
 			k.setValidatorEthereumAddress(ctx, valAddr, currEthAddr)
 		}
@@ -80,7 +82,7 @@ func (k msgServer) SetDelegateKeys(c context.Context, msg *types.MsgDelegateKeys
 	// check if the orchestrator address is currently not used
 	ethAddrs := k.getEthereumAddressesByOrchestrator(ctx, orchAddr)
 	if len(ethAddrs) > 0 {
-		if len(currEthAddr) > 0 {
+		if !bytes.Equal(emptyEthAddr.Bytes(), currEthAddr.Bytes()) {
 			// reset to the original value in case of failure
 			k.setValidatorEthereumAddress(ctx, valAddr, currEthAddr)
 		}

--- a/module/x/gravity/keeper/msg_server.go
+++ b/module/x/gravity/keeper/msg_server.go
@@ -73,19 +73,21 @@ func (k msgServer) SetDelegateKeys(c context.Context, msg *types.MsgDelegateKeys
 
 	currOrchAddr := k.GetEthereumOrchestratorAddress(ctx, currEthAddr)
 	if len(currOrchAddr) > 0 {
-		k.DeleteEthereumOrchestratorAddress(ctx, ethAddr)
+		k.DeleteEthereumOrchestratorAddress(ctx, currEthAddr)
+		k.DeleteOrchestratorValidatorAddress(ctx, currOrchAddr)
 	}
 
 	// check if the orchestrator address is currently not used
 	ethAddrs := k.getEthereumAddressesByOrchestrator(ctx, orchAddr)
 	if len(ethAddrs) > 0 {
-		if len(currOrchAddr) > 0 {
-			// reset to the original value in case of failure
-			k.setEthereumOrchestratorAddress(ctx, currEthAddr, currOrchAddr)
-		}
 		if len(currEthAddr) > 0 {
 			// reset to the original value in case of failure
 			k.setValidatorEthereumAddress(ctx, valAddr, currEthAddr)
+		}
+		if len(currOrchAddr) > 0 {
+			// reset to the original value in case of failure
+			k.setEthereumOrchestratorAddress(ctx, currEthAddr, currOrchAddr)
+			k.SetOrchestratorValidatorAddress(ctx, valAddr, currOrchAddr)
 		}
 
 		return nil, sdkerrors.Wrapf(types.ErrDelegateKeys, "orchestrator address %s in use", orchAddr)

--- a/module/x/gravity/keeper/msg_server.go
+++ b/module/x/gravity/keeper/msg_server.go
@@ -60,7 +60,7 @@ func (k msgServer) SetDelegateKeys(c context.Context, msg *types.MsgDelegateKeys
 		k.DeleteValidatorEthereumAddress(ctx, valAddr)
 	}
 
-	// check if Ethereum address is currently not used
+	// check if the Ethereum address is currently not used
 	validators := k.getValidatorsByEthereumAddress(ctx, ethAddr)
 	if len(validators) > 0 {
 		if len(currEthAddr) > 0 {
@@ -76,7 +76,7 @@ func (k msgServer) SetDelegateKeys(c context.Context, msg *types.MsgDelegateKeys
 		k.DeleteEthereumOrchestratorAddress(ctx, ethAddr)
 	}
 
-	// check orchestrator is not currently used
+	// check if the orchestrator address is currently not used
 	ethAddrs := k.getEthereumAddressesByOrchestrator(ctx, orchAddr)
 	if len(ethAddrs) > 0 {
 		if len(currOrchAddr) > 0 {

--- a/module/x/gravity/keeper/msg_server_test.go
+++ b/module/x/gravity/keeper/msg_server_test.go
@@ -417,7 +417,16 @@ func TestMsgServer_SetDelegateKeys_Existing(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			_, err = msgServer.SetDelegateKeys(sdk.WrapSDKContext(ctx), tc.msg)
-			require.Equalf(t, tc.expectErr, err != nil, "unexpected result: %v", err)
+			if err != nil {
+				require.Error(t, err, "expected error")
+
+				// ensure values remain unchanged in case of error
+				currEthAddr := gk.GetValidatorEthereumAddress(ctx, valAddr1)
+				require.Equal(t, valMsg.EthereumAddress, currEthAddr.String())
+				require.Equal(t, valMsg.OrchestratorAddress, gk.GetEthereumOrchestratorAddress(ctx, currEthAddr).String())
+			} else {
+				require.NoError(t, err, "unexpected error")
+			}
 
 			// reset state
 			_, err = msgServer.SetDelegateKeys(sdk.WrapSDKContext(ctx), valMsg)

--- a/module/x/gravity/keeper/msg_server_test.go
+++ b/module/x/gravity/keeper/msg_server_test.go
@@ -298,7 +298,10 @@ func TestMsgServer_SubmitEthereumEvent(t *testing.T) {
 }
 
 func TestMsgServer_SetDelegateKeys(t *testing.T) {
-	ethPrivKey, err := ethCrypto.GenerateKey()
+	ethPrivKey1, err := ethCrypto.GenerateKey()
+	require.NoError(t, err)
+
+	ethPrivKey2, err := ethCrypto.GenerateKey()
 	require.NoError(t, err)
 
 	var (
@@ -306,9 +309,13 @@ func TestMsgServer_SetDelegateKeys(t *testing.T) {
 		ctx = env.Context
 		gk  = env.GravityKeeper
 
-		orcAddr1, _ = sdk.AccAddressFromBech32("cosmos1dg55rtevlfxh46w88yjpdd08sqhh5cc3xhkcej")
-		valAddr1    = sdk.ValAddress(orcAddr1)
-		ethAddr1    = crypto.PubkeyToAddress(ethPrivKey.PublicKey)
+		orcAddr1 = sdk.AccAddress("addr1_______________")
+		valAddr1 = sdk.ValAddress(orcAddr1)
+		ethAddr1 = crypto.PubkeyToAddress(ethPrivKey1.PublicKey)
+
+		orcAddr2 = sdk.AccAddress("addr2_______________")
+		valAddr2 = sdk.ValAddress(orcAddr2)
+		ethAddr2 = crypto.PubkeyToAddress(ethPrivKey2.PublicKey)
 	)
 
 	// setup for getSignerValidator
@@ -321,9 +328,24 @@ func TestMsgServer_SetDelegateKeys(t *testing.T) {
 		OrchestratorAddress: orcAddr1.String(),
 		EthereumAddress:     ethAddr1.String(),
 	}
-
 	_, err = msgServer.SetDelegateKeys(sdk.WrapSDKContext(ctx), msg)
 	require.NoError(t, err)
+
+	otherValMsg := &types.MsgDelegateKeys{
+		ValidatorAddress:    valAddr2.String(),
+		OrchestratorAddress: orcAddr1.String(),
+		EthereumAddress:     ethAddr1.String(),
+	}
+	_, err = msgServer.SetDelegateKeys(sdk.WrapSDKContext(ctx), otherValMsg)
+	require.Error(t, err)
+
+	otherValMsg = &types.MsgDelegateKeys{
+		ValidatorAddress:    valAddr2.String(),
+		OrchestratorAddress: orcAddr1.String(),
+		EthereumAddress:     ethAddr2.String(),
+	}
+	_, err = msgServer.SetDelegateKeys(sdk.WrapSDKContext(ctx), otherValMsg)
+	require.Error(t, err)
 }
 
 func TestMsgServer_SetDelegateKeys_Existing(t *testing.T) {

--- a/module/x/gravity/types/errors.go
+++ b/module/x/gravity/types/errors.go
@@ -7,4 +7,5 @@ import (
 var (
 	ErrInvalid        = sdkerrors.Register(ModuleName, 3, "invalid")
 	ErrSupplyOverflow = sdkerrors.Register(ModuleName, 4, "malicious ERC20 with invalid supply sent over bridge")
+	ErrDelegateKeys   = sdkerrors.Register(ModuleName, 5, "failed to delegate keys")
 )


### PR DESCRIPTION
- Fix error handling in `msgServer#SetDelegateKeys`
- Cleanup some store logic for the `Keeper`
- Update `msgServer#SetDelegateKeys` to allow updating _either_ key, Ethereum and/or orchestrator, in their delegate key set.