### PR TITLE
Proto-breakage action fix

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -3,6 +3,7 @@ VERSION := $(shell git describe --abbrev=6 --dirty --always --tags)
 COMMIT := $(shell git log -1 --format='%H')
 DOCKER := $(shell which docker)
 DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bufbuild/buf
+HTTPS_GIT := https://github.com/peggyjv/gravity-bridge.git
 
 build_tags = netgo
 ifeq ($(LEDGER_ENABLED),true)
@@ -92,8 +93,8 @@ proto-lint:
 	@$(DOCKER_BUF) lint --error-format=json
 
 proto-check-breaking:
-	@echo $(DOCKER_BUF) breaking --against "$(env.HTTPS_GIT)#branch=main"
-	@$(DOCKER_BUF) breaking --against "$(env.HTTPS_GIT)#branch=main"
+	@echo $(DOCKER_BUF) breaking --against "$(HTTPS_GIT)#branch=main"
+	@$(DOCKER_BUF) breaking --against "$(HTTPS_GIT)#branch=main"
 
 TM_URL           = https://raw.githubusercontent.com/tendermint/tendermint/v0.34.0-rc3/proto/tendermint
 GOGO_PROTO_URL   = https://raw.githubusercontent.com/regen-network/protobuf/cosmos


### PR DESCRIPTION
The proto-breakage action would always fail, because it depended on an env var that was unset. This should make it work.