### PR TITLE
gorc: disambiguate recover & import; introduce `gorc keys eth import`

### DIFF
--- a/orchestrator/gorc/src/commands/keys/cosmos.rs
+++ b/orchestrator/gorc/src/commands/keys/cosmos.rs
@@ -1,7 +1,7 @@
 mod add;
 mod delete;
-mod import;
 mod list;
+mod recover;
 mod rename;
 mod show;
 
@@ -12,11 +12,11 @@ pub enum CosmosKeysCmd {
     #[options(help = "add [name]")]
     Add(add::AddCosmosKeyCmd),
 
-    #[options(help = "import [name] (bip39-mnemnoic)")]
-    Import(import::ImportCosmosKeyCmd),
-
     #[options(help = "delete [name]")]
     Delete(delete::DeleteCosmosKeyCmd),
+
+    #[options(help = "import [name] (bip39-mnemnoic)")]
+    Recover(recover::RecoverCosmosKeyCmd),
 
     #[options(help = "rename [name] [new-name]")]
     Rename(rename::RenameCosmosKeyCmd),

--- a/orchestrator/gorc/src/commands/keys/cosmos/add.rs
+++ b/orchestrator/gorc/src/commands/keys/cosmos/add.rs
@@ -1,7 +1,6 @@
 use super::show::ShowCosmosKeyCmd;
 use crate::application::APP;
 use abscissa_core::{Application, Command, Options, Runnable};
-use bip32;
 use k256::pkcs8::ToPrivateKey;
 use rand_core::OsRng;
 use signatory::FsKeyStore;

--- a/orchestrator/gorc/src/commands/keys/cosmos/recover.rs
+++ b/orchestrator/gorc/src/commands/keys/cosmos/recover.rs
@@ -1,28 +1,28 @@
 use super::show::ShowCosmosKeyCmd;
 use crate::application::APP;
 use abscissa_core::{Application, Command, Options, Runnable};
-use bip32;
 use k256::pkcs8::ToPrivateKey;
 use signatory::FsKeyStore;
 use std::path;
 
 #[derive(Command, Debug, Default, Options)]
-pub struct ImportCosmosKeyCmd {
-    #[options(free, help = "import [name] (bip39-mnemonic)")]
+pub struct RecoverCosmosKeyCmd {
+    #[options(free, help = "recover [name] (bip39-mnemonic)")]
     pub args: Vec<String>,
 
     #[options(help = "overwrite existing key")]
     pub overwrite: bool,
 }
 
-// `gorc keys cosmos import [name] (bip39-mnemonic)`
+// `gorc keys cosmos recover [name] (bip39-mnemonic)`
 // - [name] required; key name
 // - (bip39-mnemonic) optional; when absent the user will be prompted to enter it
-impl Runnable for ImportCosmosKeyCmd {
+impl Runnable for RecoverCosmosKeyCmd {
     fn run(&self) {
         let config = APP.config();
         let keystore = path::Path::new(&config.keystore);
-        let keystore = FsKeyStore::create_or_open(keystore).expect("Could not open keystore");
+        let keystore =
+            FsKeyStore::create_or_open(keystore).expect("Could not open keystore");
 
         let name = self.args.get(0).expect("name is required");
         let name = name.parse().expect("Could not parse name");
@@ -35,8 +35,10 @@ impl Runnable for ImportCosmosKeyCmd {
 
         let mnemonic = match self.args.get(1) {
             Some(mnemonic) => mnemonic.clone(),
-            None => rpassword::read_password_from_tty(Some("> Enter your bip39-mnemonic:\n"))
-                .expect("Could not read mnemonic"),
+            None => rpassword::read_password_from_tty(Some(
+                "> Enter your bip39-mnemonic:\n",
+            ))
+            .expect("Could not read mnemonic"),
         };
 
         let mnemonic = bip32::Mnemonic::new(mnemonic.trim(), Default::default())

--- a/orchestrator/gorc/src/commands/keys/eth.rs
+++ b/orchestrator/gorc/src/commands/keys/eth.rs
@@ -2,8 +2,9 @@ mod add;
 mod delete;
 mod import;
 mod list;
-mod show;
+mod recover;
 mod rename;
+mod show;
 
 use abscissa_core::{Command, Options, Runnable};
 
@@ -12,17 +13,20 @@ pub enum EthKeysCmd {
     #[options(help = "add [name]")]
     Add(add::AddEthKeyCmd),
 
-    #[options(help = "import [name] (bip39-mnemonic)")]
-    Import(import::ImportEthKeyCmd),
-
     #[options(help = "delete [name]")]
     Delete(delete::DeleteEthKeyCmd),
 
-    #[options(help = "rename [name] [new-name]")]
-    Rename(rename::RenameEthKeyCmd),
+    #[options(help = "import [name] (private-key)")]
+    Import(import::ImportEthKeyCmd),
 
     #[options(help = "list")]
     List(list::ListEthKeyCmd),
+
+    #[options(help = "recover [name] (bip39-mnemonic)")]
+    Recover(recover::RecoverEthKeyCmd),
+
+    #[options(help = "rename [name] [new-name]")]
+    Rename(rename::RenameEthKeyCmd),
 
     #[options(help = "show [name]")]
     Show(show::ShowEthKeyCmd),

--- a/orchestrator/gorc/src/commands/keys/eth/list.rs
+++ b/orchestrator/gorc/src/commands/keys/eth/list.rs
@@ -4,7 +4,10 @@ use abscissa_core::{Application, Command, Options, Runnable};
 use std::path;
 
 #[derive(Command, Debug, Default, Options)]
-pub struct ListEthKeyCmd {}
+pub struct ListEthKeyCmd {
+    #[options(help = "show private key")]
+    pub show_private_key: bool,
+}
 
 // Entry point for `gorc keys eth list`
 impl Runnable for ListEthKeyCmd {
@@ -19,8 +22,11 @@ impl Runnable for ListEthKeyCmd {
                     if extension == "pem" {
                         let name = path.file_stem().unwrap();
                         let name = name.to_str().unwrap();
-                        let args = vec![name.to_string()];
-                        let show_cmd = ShowEthKeyCmd { args };
+                        let show_cmd = ShowEthKeyCmd {
+                            args: vec![name.to_string()],
+                            show_private_key: self.show_private_key,
+                            show_name: true,
+                        };
                         show_cmd.run();
                     }
                 }

--- a/orchestrator/gorc/src/commands/keys/eth/recover.rs
+++ b/orchestrator/gorc/src/commands/keys/eth/recover.rs
@@ -2,13 +2,12 @@ use super::show::ShowEthKeyCmd;
 use crate::application::APP;
 use abscissa_core::{Application, Command, Options, Runnable};
 use k256::pkcs8::ToPrivateKey;
-use rand_core::OsRng;
 use signatory::FsKeyStore;
 use std::path;
 
 #[derive(Command, Debug, Default, Options)]
-pub struct AddEthKeyCmd {
-    #[options(free, help = "add [name]")]
+pub struct RecoverEthKeyCmd {
+    #[options(free, help = "recover [name] (bip39-mnemonic)")]
     pub args: Vec<String>,
 
     #[options(help = "overwrite existing key")]
@@ -18,13 +17,15 @@ pub struct AddEthKeyCmd {
     show_private_key: bool,
 }
 
-// Entry point for `gorc keys eth add [name]`
+// Entry point for `gorc keys eth recover [name] (bip39-mnemonic)`
 // - [name] required; key name
-impl Runnable for AddEthKeyCmd {
+// - (bip39-mnemonic) optional; when absent the user will be prompted to enter it
+impl Runnable for RecoverEthKeyCmd {
     fn run(&self) {
         let config = APP.config();
         let keystore = path::Path::new(&config.keystore);
-        let keystore = FsKeyStore::create_or_open(keystore).expect("Could not open keystore");
+        let keystore =
+            FsKeyStore::create_or_open(keystore).expect("Could not open keystore");
 
         let name = self.args.get(0).expect("name is required");
         let name = name.parse().expect("Could not parse name");
@@ -35,9 +36,16 @@ impl Runnable for AddEthKeyCmd {
             }
         }
 
-        let mnemonic = bip32::Mnemonic::random(&mut OsRng, Default::default());
-        eprintln!("**Important** record this bip39-mnemonic in a safe place:");
-        println!("{}", mnemonic.phrase());
+        let mnemonic = match self.args.get(1) {
+            Some(mnemonic) => mnemonic.clone(),
+            None => rpassword::read_password_from_tty(Some(
+                "> Enter your bip39-mnemonic:\n",
+            ))
+            .expect("Could not read mnemonic"),
+        };
+
+        let mnemonic = bip32::Mnemonic::new(mnemonic.trim(), Default::default())
+            .expect("Could not parse mnemonic");
 
         let seed = mnemonic.to_seed("");
 

--- a/orchestrator/gorc/src/commands/keys/eth/show.rs
+++ b/orchestrator/gorc/src/commands/keys/eth/show.rs
@@ -5,6 +5,11 @@ use abscissa_core::{Application, Command, Options, Runnable};
 pub struct ShowEthKeyCmd {
     #[options(free, help = "show [name]")]
     pub args: Vec<String>,
+
+    #[options(help = "show private key")]
+    pub show_private_key: bool,
+
+    pub show_name: bool,
 }
 
 // Entry point for `gorc keys eth show [name]`
@@ -16,6 +21,14 @@ impl Runnable for ShowEthKeyCmd {
 
         let pub_key = key.to_public_key().expect("Could not build public key");
 
-        println!("{}\t{}", name, pub_key);
+        if self.show_name {
+            print!("{}\t", name);
+        }
+
+        if self.show_private_key {
+            println!("{}\t{}", pub_key, key);
+        } else {
+            println!("{}", pub_key);
+        }
     }
 }


### PR DESCRIPTION
This renames two existing sub-commands and adds one new command. The goal of this change is to let us work directly with eth private keys; since that's how we originally configured things, pre-gorc.

Rename 1:
`gorc keys cosmos import [name] (bip39-mnemonic)` is now 
`gorc keys cosmos recover [name] (bip39-mnemonic)`

Rename 2:
`gorc keys eth import [name] (bip39-mnemonic)` is now 
`gorc keys eth recover [name] (bip39-mnemonic)`

Addition 1:
`gorc keys eth import [name] (private-key)` exists. 


## Demo

```bash
$ ## manually removing my keystore
$ rm -fr /tmp/keystore && mkdir /tmp/keystore

$ ## list all keys; confirm there are none
$ cargo -q run -- keys eth list --show-private-key

$ ## add an eth key
$ cargo -q run -- keys eth add eth-k1 --show-private-key
**Important** record this bip39-mnemonic in a safe place:
point you erosion carpet weasel apart divorce taxi topic seven order riot payment auction farm rude eager tribe mansion pond learn scan day walnut
0x22139439B727BacC325B624b8EbCaf54aF5a3669      0x76346377a1e2719d7ea3eb3142685817f83541aab0fc6ebdaae7f307125a4c24

$ ## confirm we can list the key we just added
$ cargo -q run -- keys eth list --show-private-key
eth-k1  0x22139439B727BacC325B624b8EbCaf54aF5a3669      0x76346377a1e2719d7ea3eb3142685817f83541aab0fc6ebdaae7f307125a4c24

$ ## __recover__ using the mnemonic; confirm private key matches
$ cargo -q run -- keys eth recover eth-k2 "point you erosion carpet weasel apart divorce taxi topic seven order riot payment auction farm rude eager tribe mansion pond learn scan day walnut" --show-private-key
0x22139439B727BacC325B624b8EbCaf54aF5a3669      0x76346377a1e2719d7ea3eb3142685817f83541aab0fc6ebdaae7f307125a4c24

$ ## confirm we can list the key we just recovered
$ cargo -q run -- keys eth list --show-private-key
eth-k1  0x22139439B727BacC325B624b8EbCaf54aF5a3669      0x76346377a1e2719d7ea3eb3142685817f83541aab0fc6ebdaae7f307125a4c24
eth-k2  0x22139439B727BacC325B624b8EbCaf54aF5a3669      0x76346377a1e2719d7ea3eb3142685817f83541aab0fc6ebdaae7f307125a4c24

$ ## __import__ using the private key; confirm private key matches
$ cargo -q run -- keys eth import eth-k3 "0x76346377a1e2719d7ea3eb3142685817f83541aab0fc6ebdaae7f307125a4c24" --show-private-key
0x22139439B727BacC325B624b8EbCaf54aF5a3669      0x76346377a1e2719d7ea3eb3142685817f83541aab0fc6ebdaae7f307125a4c24

$ ## list all 3 keys; confirm they all agree:
$ cargo -q run -- keys eth list --show-private-key
eth-k1  0x22139439B727BacC325B624b8EbCaf54aF5a3669      0x76346377a1e2719d7ea3eb3142685817f83541aab0fc6ebdaae7f307125a4c24
eth-k2  0x22139439B727BacC325B624b8EbCaf54aF5a3669      0x76346377a1e2719d7ea3eb3142685817f83541aab0fc6ebdaae7f307125a4c24
eth-k3  0x22139439B727BacC325B624b8EbCaf54aF5a3669      0x76346377a1e2719d7ea3eb3142685817f83541aab0fc6ebdaae7f307125a4c24
```