### PR TITLE
Refactor SDK Configuration

### DIFF
--- a/module/app/address.go
+++ b/module/app/address.go
@@ -1,0 +1,13 @@
+package app
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// SetAddressConfig sets the gravity app's address configuration.
+func SetAddressConfig() {
+	config := sdk.GetConfig()
+
+	config.SetAddressVerifier(VerifyAddressFormat)
+	config.Seal()
+}

--- a/module/app/app.go
+++ b/module/app/app.go
@@ -220,9 +220,6 @@ func init() {
 	}
 
 	DefaultNodeHome = filepath.Join(userHomeDir, ".gravity")
-
-	sdk.GetConfig().SetAddressVerifier(VerifyAddressFormat)
-	sdk.GetConfig().Seal()
 }
 
 func NewGravityApp(

--- a/module/cmd/gravity/cmd/root.go
+++ b/module/cmd/gravity/cmd/root.go
@@ -36,6 +36,8 @@ import (
 // NewRootCmd creates a new root command for simd. It is called once in the
 // main function.
 func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
+	app.SetAddressConfig()
+
 	encodingConfig := app.MakeEncodingConfig()
 	initClientCtx := client.Context{}.
 		WithCodec(encodingConfig.Marshaler).

--- a/module/cmd/gravity/cmd/root.go
+++ b/module/cmd/gravity/cmd/root.go
@@ -84,9 +84,6 @@ func Execute(rootCmd *cobra.Command) error {
 }
 
 func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
-	cfg := sdk.GetConfig()
-	cfg.Seal()
-
 	rootCmd.AddCommand(
 		genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),

--- a/module/x/gravity/types/msgs_test.go
+++ b/module/x/gravity/types/msgs_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestValidateMsgDelegateKeys(t *testing.T) {
+	app.SetAddressConfig()
+
 	var (
 		ethAddress                   = "0xb462864E395d88d6bc7C5dd5F3F5eb4cc2599255"
 		cosmosAddress sdk.AccAddress = bytes.Repeat([]byte{0x1}, app.MaxAddrLen)


### PR DESCRIPTION
In order for an upstream application that wants to use any of the Gravity Bridge's commands or CLI functionality, the SDK configuration cannot be done in any `init` call, otherwise the SDK will panic as the config will be sealed.

This means that the gravity bridge will have to call the SDK configuration setting elsewhere outside of an `init`. A good enough place is in the root command constructor.