### PR TITLE
Fix EthereumEventProcessor events

### DIFF
--- a/module/x/gravity/keeper/ethereum_event_vote.go
+++ b/module/x/gravity/keeper/ethereum_event_vote.go
@@ -130,6 +130,7 @@ func (k Keeper) processEthereumEvent(ctx sdk.Context, event types.EthereumEvent)
 			"nonce", fmt.Sprint(event.GetEventNonce()),
 		)
 	} else {
+		ctx.EventManager().EmitEvents(xCtx.EventManager().Events()) // copy events to original context
 		commit() // persist transient storage
 	}
 }


### PR DESCRIPTION
Copy the events from the cache context to the original context, otherwise they will be ignored