### PR TITLE
* Fixed clap panic when using `keys eth show` command.

### DIFF
--- a/orchestrator/gorc/src/commands/keys/eth/show.rs
+++ b/orchestrator/gorc/src/commands/keys/eth/show.rs
@@ -9,7 +9,7 @@ pub struct ShowEthKeyCmd {
     #[clap(short, long)]
     pub show_private_key: bool,
 
-    #[clap(short, long)]
+    #[clap(short = 'n', long)]
     pub show_name: bool,
 }
 


### PR DESCRIPTION
When executing `keys eth show` command.

App panicked with:

  thread 'main' panicked at 'Short option names must be unique for each argument, but '-s' is in use by both 'show-private-key' and 'show-name''

It may be better to rename command records everywhere as following:

```
show_private_key => private_key_show
show_name => name_show
```