### PR TITLE
Denomination sanity check in send_to_eth()

### DIFF
--- a/orchestrator/cosmos_gravity/src/send.rs
+++ b/orchestrator/cosmos_gravity/src/send.rs
@@ -75,6 +75,13 @@ pub async fn send_to_eth(
     contact: &Contact,
     gas_adjustment: f64,
 ) -> Result<TxResponse, CosmosGrpcError> {
+    if amount.denom != bridge_fee.denom {
+        return Err(CosmosGrpcError::BadInput(format!(
+            "The amount ({}) and bridge_fee ({}) denominations do not match.",
+            amount.denom, bridge_fee.denom,
+        )))
+    }
+
     let cosmos_address = cosmos_key.to_address(&contact.get_prefix()).unwrap();
 
     let msg = proto::MsgSendToEthereum {


### PR DESCRIPTION
Closes #260 

Ensures that the `amount` and `bridge_fee` denominations match inside of the `send_to_eth()` method.