### PR TITLE
Collin/error handling

### DIFF
--- a/orchestrator/ethereum_gravity/src/logic_call.rs
+++ b/orchestrator/ethereum_gravity/src/logic_call.rs
@@ -1,10 +1,6 @@
 use crate::{
     types::{EthClient, EthSignerMiddleware},
-    utils::{
-        get_logic_call_nonce,
-        get_gas_price,
-        GasCost,
-    },
+    utils::{get_gas_price, get_logic_call_nonce, GasCost},
 };
 use ethers::contract::builders::ContractCall;
 use ethers::prelude::*;

--- a/orchestrator/ethereum_gravity/src/valset_update.rs
+++ b/orchestrator/ethereum_gravity/src/valset_update.rs
@@ -26,7 +26,6 @@ pub async fn send_eth_valset_update(
 ) -> Result<(), GravityError> {
     let old_nonce = old_valset.nonce;
     let new_nonce = new_valset.nonce;
-    assert!(new_nonce > old_nonce);
 
     info!(
         "Ordering signatures and submitting validator set {} -> {} update to Ethereum",

--- a/orchestrator/gravity_utils/src/error.rs
+++ b/orchestrator/gravity_utils/src/error.rs
@@ -1,6 +1,5 @@
 //! for things that don't belong in the cosmos or ethereum libraries but also don't belong
 //! in a function specific library
-
 use clarity::Error as ClarityError;
 use deep_space::error::AddressError as CosmosAddressError;
 use deep_space::error::CosmosGrpcError;
@@ -23,6 +22,8 @@ use std::num::ParseIntError;
 use std::string::FromUtf8Error;
 use tokio::time::error::Elapsed;
 use tonic::Status;
+
+use crate::types::ValsetsNoncePair;
 
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -57,6 +58,7 @@ pub enum GravityError {
     ParseIntError(ParseIntError),
     FromUtf8Error(FromUtf8Error),
     OverflowError(String),
+    DifferingValsetNoncesError(ValsetsNoncePair),
 }
 
 impl fmt::Display for GravityError {
@@ -112,8 +114,13 @@ impl fmt::Display for GravityError {
             GravityError::ParseIntError(val) => write!(f, "Failed to parse integer: {}", val),
             GravityError::FromUtf8Error(val) => {
                 write!(f, "Failed to parse bytes to UTF-8: {}", val)
-            },
+            }
             GravityError::OverflowError(val) => write!(f, "Overflow error: {}", val),
+            GravityError::DifferingValsetNoncesError(nonces) => write!(
+                f,
+                "Cosmos valset nonce ({}) and Ethereum valset nonce ({}) do not match!",
+                nonces.cosmos_nonce, nonces.ethereum_nonce
+            ),
         }
     }
 }

--- a/orchestrator/gravity_utils/src/error.rs
+++ b/orchestrator/gravity_utils/src/error.rs
@@ -23,8 +23,6 @@ use std::string::FromUtf8Error;
 use tokio::time::error::Elapsed;
 use tonic::Status;
 
-use crate::types::ValsetsNoncePair;
-
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum GravityError {
@@ -58,7 +56,6 @@ pub enum GravityError {
     ParseIntError(ParseIntError),
     FromUtf8Error(FromUtf8Error),
     OverflowError(String),
-    DifferingValsetNoncesError(ValsetsNoncePair),
 }
 
 impl fmt::Display for GravityError {
@@ -116,11 +113,6 @@ impl fmt::Display for GravityError {
                 write!(f, "Failed to parse bytes to UTF-8: {}", val)
             }
             GravityError::OverflowError(val) => write!(f, "Overflow error: {}", val),
-            GravityError::DifferingValsetNoncesError(nonces) => write!(
-                f,
-                "Cosmos valset nonce ({}) and Ethereum valset nonce ({}) do not match!",
-                nonces.cosmos_nonce, nonces.ethereum_nonce
-            ),
         }
     }
 }

--- a/orchestrator/gravity_utils/src/types/batches.rs
+++ b/orchestrator/gravity_utils/src/types/batches.rs
@@ -64,9 +64,6 @@ impl TransactionBatch {
             .map(|tx| tx.erc20_fee.amount)
             .collect();
 
-        assert_eq!(amounts.len(), destinations.len());
-        assert_eq!(fees.len(), destinations.len());
-
         (amounts, destinations, fees)
     }
 
@@ -96,7 +93,7 @@ impl TransactionBatch {
                 if running_amount.is_none() {
                     return Err(GravityError::OverflowError(
                         format!("U256 overflow when adding all fees together for transaction batch with nonce {}", input.batch_nonce)
-                    ))
+                    ));
                 }
 
                 running_total_fee = Some(Erc20Token {

--- a/orchestrator/gravity_utils/src/types/valsets.rs
+++ b/orchestrator/gravity_utils/src/types/valsets.rs
@@ -149,7 +149,6 @@ impl Valset {
         for member in self.members.iter() {
             if let Some(eth_address) = member.eth_address {
                 if let Some(sig) = signatures_hashmap.get(&eth_address) {
-                    assert_eq!(sig.get_eth_address(), eth_address);
                     let sig_hash = u8_slice_to_fixed_32(signed_message)?;
                     let recover_key = sig.get_signature().recover(sig_hash)?;
                     if recover_key == sig.get_eth_address() {

--- a/orchestrator/gravity_utils/src/types/valsets.rs
+++ b/orchestrator/gravity_utils/src/types/valsets.rs
@@ -413,3 +413,22 @@ impl From<&ValsetMember> for gravity_proto::gravity::EthereumSigner {
         }
     }
 }
+
+// A convenience struct for reporting errors with mismatched valset nonces. The
+// reason two integers were not instead passed to the GravityError::DifferingValsetNoncesError
+// variant is that we need to ensure the nonces are associated with their appropriate
+// valset in the log message.
+#[derive(Debug)]
+pub struct ValsetsNoncePair {
+    pub cosmos_nonce: u64,
+    pub ethereum_nonce: u64,
+}
+
+impl From<(u64, u64)> for ValsetsNoncePair {
+    fn from(input: (u64, u64)) -> Self {
+        ValsetsNoncePair {
+            cosmos_nonce: input.0,
+            ethereum_nonce: input.1,
+        }
+    }
+}

--- a/orchestrator/gravity_utils/src/types/valsets.rs
+++ b/orchestrator/gravity_utils/src/types/valsets.rs
@@ -413,22 +413,3 @@ impl From<&ValsetMember> for gravity_proto::gravity::EthereumSigner {
         }
     }
 }
-
-// A convenience struct for reporting errors with mismatched valset nonces. The
-// reason two integers were not instead passed to the GravityError::DifferingValsetNoncesError
-// variant is that we need to ensure the nonces are associated with their appropriate
-// valset in the log message.
-#[derive(Debug)]
-pub struct ValsetsNoncePair {
-    pub cosmos_nonce: u64,
-    pub ethereum_nonce: u64,
-}
-
-impl From<(u64, u64)> for ValsetsNoncePair {
-    fn from(input: (u64, u64)) -> Self {
-        ValsetsNoncePair {
-            cosmos_nonce: input.0,
-            ethereum_nonce: input.1,
-        }
-    }
-}

--- a/orchestrator/relayer/src/batch_relaying.rs
+++ b/orchestrator/relayer/src/batch_relaying.rs
@@ -222,7 +222,7 @@ async fn submit_batches(
                 .await;
 
                 if res.is_err() {
-                    info!("Batch submission failed with {:?}", res);
+                    warn!("Batch submission failed with {:?}", res);
                 }
             }
         }

--- a/orchestrator/relayer/src/find_latest_valset.rs
+++ b/orchestrator/relayer/src/find_latest_valset.rs
@@ -94,14 +94,6 @@ fn check_if_valsets_differ(
     }
     let cosmos_valset = cosmos_valset.unwrap();
     if cosmos_valset != *ethereum_valset {
-        // if this is true then we have a logic error on the Cosmos chain
-        // or with our Ethereum search
-        if cosmos_valset.nonce != ethereum_valset.nonce {
-            return Err(GravityError::InvalidBridgeStateError(
-                format!("validator set nonces do not match (cosmos: {}, ethereum: {})", cosmos_valset.nonce, ethereum_valset.nonce),
-            ));
-        }
-
         let mut c_valset = cosmos_valset.members;
         let mut e_valset = ethereum_valset.members.clone();
         c_valset.sort();

--- a/orchestrator/relayer/src/find_latest_valset.rs
+++ b/orchestrator/relayer/src/find_latest_valset.rs
@@ -3,7 +3,7 @@ use ethers::prelude::*;
 use ethers::types::Address as EthAddress;
 use gravity_abi::gravity::*;
 use gravity_proto::gravity::query_client::QueryClient as GravityQueryClient;
-use gravity_utils::types::{FromLog, ValsetUpdatedEvent, ValsetsNoncePair};
+use gravity_utils::types::{FromLog, ValsetUpdatedEvent};
 use gravity_utils::{error::GravityError, ethereum::downcast_to_u64, types::Valset};
 use std::{panic, result::Result};
 use tonic::transport::Channel;
@@ -97,12 +97,8 @@ fn check_if_valsets_differ(
         // if this is true then we have a logic error on the Cosmos chain
         // or with our Ethereum search
         if cosmos_valset.nonce != ethereum_valset.nonce {
-            error!(
-                "Cosmos valset nonce ({}) and Ethereum valset nonce ({}) are not the same!",
-                cosmos_valset.nonce, ethereum_valset.nonce
-            );
-            return Err(GravityError::DifferingValsetNoncesError(
-                ValsetsNoncePair::from((cosmos_valset.nonce, ethereum_valset.nonce)),
+            return Err(GravityError::InvalidBridgeStateError(
+                format!("validator set nonces do not match (cosmos: {}, ethereum: {})", cosmos_valset.nonce, ethereum_valset.nonce),
             ));
         }
 

--- a/orchestrator/relayer/src/main.rs
+++ b/orchestrator/relayer/src/main.rs
@@ -89,10 +89,8 @@ async fn main() {
         .await
         .expect("Could not retrieve chain ID during relayer start");
     let chain_id = downcast_to_u64(chain_id).expect("Chain ID overflowed when downcasting to u64");
-    let eth_client = SignerMiddleware::new(
-        provider,
-        ethereum_wallet.clone().with_chain_id(chain_id),
-    );
+    let eth_client =
+        SignerMiddleware::new(provider, ethereum_wallet.clone().with_chain_id(chain_id));
     let eth_client = Arc::new(eth_client);
 
     let public_eth_key = eth_client.address();

--- a/orchestrator/relayer/src/valset_relaying.rs
+++ b/orchestrator/relayer/src/valset_relaying.rs
@@ -56,49 +56,66 @@ pub async fn relay_valsets(
     // this is used to display the state of the last validator set to fail signature checks
     let mut last_error = None;
     while latest_nonce > 0 {
-        let cosmos_valset = get_valset(grpc_client, latest_nonce).await;
-        if let Ok(Some(cosmos_valset)) = cosmos_valset {
-            assert_eq!(cosmos_valset.nonce, latest_nonce);
-            let confirms = get_all_valset_confirms(grpc_client, latest_nonce).await;
-            if let Ok(confirms) = confirms {
-                debug!(
-                    "Considering cosmos_valset {:?} confirms {:?}",
-                    cosmos_valset, confirms
-                );
+        match get_valset(grpc_client, latest_nonce).await {
+            Ok(Some(cosmos_valset)) => {
+                assert_eq!(cosmos_valset.nonce, latest_nonce);
 
-                for confirm in confirms.iter() {
-                    assert_eq!(cosmos_valset.nonce, confirm.nonce);
-                }
+                match get_all_valset_confirms(grpc_client, latest_nonce).await {
+                    Ok(confirms) => {
+                        debug!(
+                            "Considering cosmos_valset {:?} confirms {:?}",
+                            cosmos_valset, confirms
+                        );
 
-                let hash = encode_valset_confirm_hashed(gravity_id.clone(), cosmos_valset.clone());
+                        for confirm in confirms.iter() {
+                            assert_eq!(cosmos_valset.nonce, confirm.nonce);
+                        }
 
-                // there are two possible encoding problems that could cause the very rare sig failure bug,
-                // one of them is that the hash is incorrect, that's not probable considering that
-                // both Geth and Clarity agree on it. but this lets us check
-                info!("New valset hash {}", bytes_to_hex_str(&hash));
+                        let hash =
+                            encode_valset_confirm_hashed(gravity_id.clone(), cosmos_valset.clone());
 
-                // order valset sigs prepares signatures for submission, notice we compare
-                // them to the 'current' set in the bridge, this confirms for us that the validator set
-                // we have here can be submitted to the bridge in it's current state
-                let res = current_eth_valset.order_sigs(&hash, &confirms);
-                if res.is_ok() {
-                    info!("Consideration: looks good");
-                    latest_confirmed = Some(confirms);
-                    latest_cosmos_valset = Some(cosmos_valset);
-                    // once we have the latest validator set we can submit exit
-                    break;
-                } else if let Err(e) = res {
-                    info!("Consideration: looks bad {}", e);
-                    last_error = Some(e);
+                        // there are two possible encoding problems that could cause the very rare sig failure bug,
+                        // one of them is that the hash is incorrect, that's not probable considering that
+                        // both Geth and Clarity agree on it. but this lets us check
+                        info!("New valset hash {}", bytes_to_hex_str(&hash),);
+
+                        // order valset sigs prepares signatures for submission, notice we compare
+                        // them to the 'current' set in the bridge, this confirms for us that the validator set
+                        // we have here can be submitted to the bridge in it's current state
+                        match current_eth_valset.order_sigs(&hash, &confirms) {
+                            Ok(_) => {
+                                info!("Consideration: looks good");
+                                latest_confirmed = Some(confirms);
+                                latest_cosmos_valset = Some(cosmos_valset);
+                                // once we have the latest validator set we can submit exit
+                                break;
+                            }
+                            Err(err) => {
+                                warn!("Consideration: looks bad. {}", err);
+                                last_error = Some(err);
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        error!(
+                            "Error getting Cosmos valset confirmations for nonce {}. {:?}",
+                            latest_nonce, err
+                        );
+                    }
                 }
             }
-            // TODO(levi) this is ignoring/swallowing errors
+            // Bootstrap condition
+            Ok(None) => (),
+            Err(err) => {
+                error!(
+                    "Error getting Cosmos valset for nonce {}. {:?}",
+                    latest_nonce, err
+                );
+            }
         }
-        // TODO(levi) this is ignoring/swallowing errors
 
         latest_nonce -= 1
     }
-    // TODO(levi) this is ignoring/swallowing errors
 
     debug!("Relaying latest_confirmed {:?}", latest_confirmed);
     debug!("Relaying latest_cosmos_valset {:?}", latest_cosmos_valset);

--- a/orchestrator/relayer/src/valset_relaying.rs
+++ b/orchestrator/relayer/src/valset_relaying.rs
@@ -77,7 +77,7 @@ pub async fn relay_valsets(
                         // there are two possible encoding problems that could cause the very rare sig failure bug,
                         // one of them is that the hash is incorrect, that's not probable considering that
                         // both Geth and Clarity agree on it. but this lets us check
-                        info!("New valset hash {}", bytes_to_hex_str(&hash),);
+                        info!("New valset hash {}", bytes_to_hex_str(&hash));
 
                         // order valset sigs prepares signatures for submission, notice we compare
                         // them to the 'current' set in the bridge, this confirms for us that the validator set


### PR DESCRIPTION
Closes #262 

Addresses problematic ~~and non-idiomatic~~ error handling. 

I judged a few assertions to be unnecessary because they asserted statements that were definitively made true by nearby code.

-  Two assertions in `gravity_utils/src/types/batches.rs` were removed because the loop immediately before them constructs them.
- An assertion in `ethereum_gravity/src/valset_update.rs` was removed because the comparison was tested earlier in valset_relaying.rs via `latest_cosmos_valset.nonce > current_eth_valset.nonce` making this check redundant.

~~I also refactored a number of unusual `Result` checks as `match` blocks.~~

EDIT: Crossed out items were not included in branch remake after Eric's PR replace web30 and other libraries.