### PR TITLE
Add a migrate function to the keeper to clean up state to move to a new gravity contract

### DIFF
--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -619,6 +619,15 @@ func (k Keeper) MigrateGravityContract(ctx sdk.Context, newBridgeAddress string,
 	}
 	store.Set([]byte{types.LastEthereumBlockHeightKey}, k.cdc.MustMarshal(&height))
 
+	k.setLastObservedSignerSetTx(ctx, types.SignerSetTx{
+		Nonce:   0,
+		Height:  0,
+		Signers: nil,
+	})
+
+	// Set the batch Nonce to zero
+	store.Set([]byte{types.LastOutgoingBatchNonceKey}, sdk.Uint64ToBigEndian(0))
+
 	// Update the bridge contract address
 	params := k.GetParams(ctx)
 	params.BridgeEthereumAddress = newBridgeAddress

--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -568,6 +568,9 @@ func (k Keeper) CreateContractCallTx(ctx sdk.Context, invalidationNonce uint64, 
 /////////////////
 
 // Clean up all state associated a previous gravity contract and set a new contract. This is intended to run in the upgrade handler.
+// This implementation is partial at best. It doees not contain necessary functionality to freeze the bridge.
+// We will have yet to implement functionality to Migrate the Cosmos ERC20 tokens or any other ERC20 tokens bridged to the gravity contracts.
+// This just does keeper state cleanup if a new gravity contract has been deployed
 func (k Keeper) MigrateGravityContract(ctx sdk.Context, newBridgeAddress string, bridgeDeploymentHeight uint64) {
 
 	// Delete Any Outgoing TXs.

--- a/module/x/gravity/keeper/keeper_test.go
+++ b/module/x/gravity/keeper/keeper_test.go
@@ -597,7 +597,7 @@ func TestKeeper_Migration(t *testing.T) {
 
 	{ // setup
 		batchTxConfirmation := &types.BatchTxConfirmation{
-			TokenContract:  "0x3146D2d6Eed46Afa423969f5dDC3152DfC359b09",
+			TokenContract:  myTokenContractAddr.Hex(),
 			BatchNonce:     firstBatch.BatchNonce,
 			EthereumSigner: ethAddr.Hex(),
 			Signature:      []byte("fake-signature"),
@@ -607,7 +607,7 @@ func TestKeeper_Migration(t *testing.T) {
 	}
 
 	{ // validate
-		storeIndex := types.MakeBatchTxKey(ethAddr, firstBatch.BatchNonce)
+		storeIndex := gotFirstBatch.GetStoreIndex()
 
 		{ // getEthereumSignature
 			got := gk.getEthereumSignature(ctx, storeIndex, valAddr)
@@ -638,8 +638,7 @@ func TestKeeper_Migration(t *testing.T) {
 	require.Equal(t, got, &types.SignerSetTx{Nonce: 0x0, Height: 0x0, Signers: types.EthereumSigners(nil)})
 
 	{ // GetEthereumSignatures
-		storeIndex := types.MakeBatchTxKey(ethAddr, firstBatch.BatchNonce)
-
+		storeIndex := gotFirstBatch.GetStoreIndex()
 		got := gk.GetEthereumSignatures(ctx, storeIndex)
 		require.Len(t, got, 0)
 	}


### PR DESCRIPTION
This pull request adds supporting infrastructure for cleaning up state and  migrating to new gravity contract.

It does not add the transactions to migrate cosmos ERC20 tokens to the new bridge: