### PR TITLE
Reset last ethereum event for each validator

### DIFF
--- a/module/x/gravity/keeper/keeper_test.go
+++ b/module/x/gravity/keeper/keeper_test.go
@@ -634,6 +634,10 @@ func TestKeeper_Migration(t *testing.T) {
 	nonce2 := gk.GetLastObservedEventNonce(ctx)
 	require.Equal(t, uint64(0), nonce2)
 
+	for _, val := range ValAddrs {
+		require.Equal(t, uint64(0), gk.getLastEventNonceByValidator(ctx, val))
+	}
+
 	got := gk.GetLastObservedSignerSetTx(ctx)
 	require.Equal(t, got, &types.SignerSetTx{Nonce: 0x0, Height: 0x0, Signers: types.EthereumSigners(nil)})
 


### PR DESCRIPTION
In addition to resetting the keeper's last observed event nonce, reset the value for each individual validator, as the oracle resync orchestrator process is retrieving the last event nonce attached to its own address.