### PR TITLE
Fix migration ethereum nonce reset per validator

### DIFF
--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -614,7 +614,7 @@ func (k Keeper) MigrateGravityContract(ctx sdk.Context, newBridgeAddress string,
 			k.setLastEventNonceByValidator(ctx, val, 0)
 		}
 
-		return true
+		return false
 	})
 
 	// Delete all Ethereum Events

--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -601,16 +601,6 @@ func (k Keeper) MigrateGravityContract(ctx sdk.Context, newBridgeAddress string,
 	store := ctx.KVStore(k.storeKey)
 	store.Set([]byte{types.LatestSignerSetTxNonceKey}, sdk.Uint64ToBigEndian(0))
 
-	prefixStoreEthereumEvent := prefix.NewStore(ctx.KVStore(k.storeKey), []byte{types.EthereumEventVoteRecordKey})
-
-	// Delete all Ethereum Events
-
-	iterEvent := prefixStoreEthereumEvent.Iterator(nil, nil)
-	defer iterEvent.Close()
-	for ; iterEvent.Valid(); iterEvent.Next() {
-		prefixStoreEthereumEvent.Delete(iterEvent.Key())
-	}
-
 	// Reset all ethereum event nonces to zero
 	k.setLastObservedEventNonce(ctx, 0)
 	k.iterateEthereumEventVoteRecords(ctx, func(_ []byte, voteRecord *types.EthereumEventVoteRecord) bool {
@@ -626,6 +616,14 @@ func (k Keeper) MigrateGravityContract(ctx sdk.Context, newBridgeAddress string,
 
 		return true
 	})
+
+	// Delete all Ethereum Events
+	prefixStoreEthereumEvent := prefix.NewStore(ctx.KVStore(k.storeKey), []byte{types.EthereumEventVoteRecordKey})
+	iterEvent := prefixStoreEthereumEvent.Iterator(nil, nil)
+	defer iterEvent.Close()
+	for ; iterEvent.Valid(); iterEvent.Next() {
+		prefixStoreEthereumEvent.Delete(iterEvent.Key())
+	}
 
 	// Set the Last oberved Ethereum Blockheight to zero
 	height := types.LatestEthereumBlockHeight{

--- a/module/x/gravity/keeper/keeper_test.go
+++ b/module/x/gravity/keeper/keeper_test.go
@@ -590,6 +590,9 @@ func TestKeeper_Migration(t *testing.T) {
 	stored := gk.GetEthereumEventVoteRecord(ctx, stce.GetEventNonce(), stce.Hash())
 	require.NotNil(t, stored)
 
+	stored2 := gk.GetEthereumEventVoteRecord(ctx, cctxe.GetEventNonce(), cctxe.Hash())
+	require.NotNil(t, stored2)
+
 	ethAddr := common.HexToAddress("0x3146D2d6Eed46Afa423969f5dDC3152DfC359b09")
 
 	valAddr, err := sdk.ValAddressFromBech32("cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4")
@@ -633,8 +636,13 @@ func TestKeeper_Migration(t *testing.T) {
 	}
 
 	gk.MigrateGravityContract(ctx, "0x5e175bE4d23Fa25604CE7848F60FB340894D5CDA", 1000)
-	stored2 := gk.GetEthereumEventVoteRecord(ctx, stce.GetEventNonce(), stce.Hash())
-	require.Nil(t, stored2)
+
+	storedAfterMigrate := gk.GetEthereumEventVoteRecord(ctx, stce.GetEventNonce(), stce.Hash())
+	require.Nil(t, storedAfterMigrate)
+
+	stored2AfterMigrate := gk.GetEthereumEventVoteRecord(ctx, cctxe.GetEventNonce(), cctxe.Hash())
+	require.Nil(t, stored2AfterMigrate)
+
 	nonce2 := gk.GetLastObservedEventNonce(ctx)
 	require.Equal(t, uint64(0), nonce2)
 

--- a/module/x/gravity/keeper/keeper_test.go
+++ b/module/x/gravity/keeper/keeper_test.go
@@ -628,6 +628,10 @@ func TestKeeper_Migration(t *testing.T) {
 		Signers: nil,
 	})
 
+	for _, val := range ValAddrs {
+		gk.setLastEventNonceByValidator(ctx, val, nonce)
+	}
+
 	gk.MigrateGravityContract(ctx, "0x5e175bE4d23Fa25604CE7848F60FB340894D5CDA", 1000)
 	stored2 := gk.GetEthereumEventVoteRecord(ctx, stce.GetEventNonce(), stce.Hash())
 	require.Nil(t, stored2)


### PR DESCRIPTION
* Make sure we only delete all ethereum events after reading them so we can correctly zero out event nonces
* Return false in the `iterateEthereumEventVoteRecords` function, or it will stop early after the first record
* In the keeper test, make sure we set the event nonces manually so the test will fail if it's not functioning correctly, and also test presence for all ethereum event records