### PR TITLE
Update block delay, use chain ID correctly

### DIFF
--- a/orchestrator/orchestrator/src/ethereum_event_watcher.rs
+++ b/orchestrator/orchestrator/src/ethereum_event_watcher.rs
@@ -262,12 +262,15 @@ pub async fn get_block_delay(eth_client: EthClient) -> Result<U64, GravityError>
     }
 
     match chain_id.unwrap() {
-        // Mainline Ethereum, Ethereum classic, or the Ropsten, Mordor testnets
+        // Mainline Ethereum, Ethereum classic, or the Kotti, Ropsten, Mordor testnets
         // all POW Chains
         1 | 3 | 61 | 63 => Ok(13u8.into()),
-        // Rinkeby, Goerli, Dev, our own Gravity Ethereum testnet, Kotti, Hardhat respectively
+        // Dev, our own Gravity Ethereum testnet, Hardhat respectively
         // all non-pow chains
-        4 | 5 | 2018 | 15 | 6 | 31337 => Ok(0u8.into()),
+        2018 | 15 | 31337 => Ok(0u8.into()),
+        // Rinkeby, Goerli, and Kotti
+        // Clique (POA) Consensus
+        4 | 5 | 6 => Ok(10u8.into()),
         // assume the safe option (POW) where we don't know
         _ => Ok(13u8.into()),
     }

--- a/orchestrator/orchestrator/src/ethereum_event_watcher.rs
+++ b/orchestrator/orchestrator/src/ethereum_event_watcher.rs
@@ -250,10 +250,8 @@ pub async fn check_for_events(
 /// 6 deep reorg every 53,272 years.
 ///
 pub async fn get_block_delay(eth_client: EthClient) -> Result<U64, GravityError> {
-    // TODO(bolten): technically we want the network id from net_version, but chain id
-    // should be the same for our use cases...when this PR is in a released version of
-    // ethers we can move back to net_version:
-    // https://github.com/gakonst/ethers-rs/pull/595
+    // TODO(bolten): get_net_version() exists on the version of ethers we are currently
+    // depending on, but it's broken, so we're relying on chain ID
     let chain_id_result = get_chain_id_with_retry(eth_client.clone()).await;
     let chain_id = downcast_to_u64(chain_id_result);
     if chain_id.is_none() {
@@ -266,11 +264,11 @@ pub async fn get_block_delay(eth_client: EthClient) -> Result<U64, GravityError>
     match chain_id.unwrap() {
         // Mainline Ethereum, Ethereum classic, or the Ropsten, Mordor testnets
         // all POW Chains
-        1 | 3 | 7 => Ok(6u8.into()),
-        // Rinkeby, Goerli, Dev, our own Gravity Ethereum testnet, and Kotti respectively
+        1 | 3 | 61 | 63 => Ok(13u8.into()),
+        // Rinkeby, Goerli, Dev, our own Gravity Ethereum testnet, Kotti, Hardhat respectively
         // all non-pow chains
-        4 | 5 | 2018 | 15 | 6 => Ok(0u8.into()),
+        4 | 5 | 2018 | 15 | 6 | 31337 => Ok(0u8.into()),
         // assume the safe option (POW) where we don't know
-        _ => Ok(6u8.into()),
+        _ => Ok(13u8.into()),
     }
 }

--- a/orchestrator/orchestrator/src/ethereum_event_watcher.rs
+++ b/orchestrator/orchestrator/src/ethereum_event_watcher.rs
@@ -262,13 +262,13 @@ pub async fn get_block_delay(eth_client: EthClient) -> Result<U64, GravityError>
     }
 
     match chain_id.unwrap() {
-        // Mainline Ethereum, Ethereum classic, or the Kotti, Ropsten, Mordor testnets
+        // Mainline Ethereum, Ethereum classic, or Ropsten, Mordor testnets
         // all POW Chains
         1 | 3 | 61 | 63 => Ok(13u8.into()),
-        // Dev, our own Gravity Ethereum testnet, Hardhat respectively
+        // Dev, our own Gravity Ethereum testnet, Hardhat
         // all non-pow chains
         2018 | 15 | 31337 => Ok(0u8.into()),
-        // Rinkeby, Goerli, and Kotti
+        // Rinkeby, Goerli, Kotti
         // Clique (POA) Consensus
         4 | 5 | 6 => Ok(10u8.into()),
         // assume the safe option (POW) where we don't know

--- a/orchestrator/orchestrator/src/get_with_retry.rs
+++ b/orchestrator/orchestrator/src/get_with_retry.rs
@@ -38,11 +38,11 @@ pub async fn get_last_event_nonce_with_retry(
     res.unwrap()
 }
 
-/// gets the net version, no matter how long it takes
+/// gets the chain ID, no matter how long it takes
 pub async fn get_chain_id_with_retry(eth_client: EthClient) -> U256 {
     let mut res = eth_client.get_chainid().await;
     while res.is_err() {
-        error!("Failed to get net version! Is your Eth node working?");
+        error!("Failed to get chain ID! Is your Eth node working?");
         delay_for(RETRY_TIME).await;
         res = eth_client.get_chainid().await;
     }


### PR DESCRIPTION
* Update our block delay to a somewhat safer value. Using 13 is still a bit low, but this mirrors what the Gravity Bridge chain is doing in production. We could choose to set a higher value as well, but 6 is too low in any case.
* The version of `ethers` we are pinned to implements `net_version` but appears to do it incorrectly, as it throws an error. As such, since we are claiming to rely on chain ID already anyway, we should use chain IDs rather than net versions in our check. Additionally, add the Hardhat chain ID to remove the block delay in our local test environment (maybe we can disable the autominer?)