### PR TITLE
Use gas multiplier for ERC20 deploy

### DIFF
--- a/orchestrator/ethereum_gravity/src/deploy_erc20.rs
+++ b/orchestrator/ethereum_gravity/src/deploy_erc20.rs
@@ -5,7 +5,7 @@
 use crate::{types::EthClient, utils::get_gas_price};
 use ethers::prelude::*;
 use gravity_abi::gravity::*;
-use gravity_utils::{error::GravityError, ethereum::downcast_to_f64};
+use gravity_utils::{error::GravityError, ethereum::{downcast_to_f64, format_eth_hash}};
 use std::{result::Result, time::Duration};
 
 /// Calls the Gravity ethereum contract to deploy the ERC20 representation of the given Cosmos asset
@@ -42,13 +42,13 @@ pub async fn deploy_erc20(
 
     let pending_tx = contract_call.send().await?;
     let tx_hash = *pending_tx;
-    info!("Deploying ERC-20 with tx hash {}", tx_hash);
+    info!("Deploying ERC-20 with tx hash {}", format_eth_hash(tx_hash));
     // TODO(bolten): ethers interval default is 7s, this mirrors what web30 was doing, should we adjust?
     // additionally we are mirroring only waiting for 1 confirmation by leaving that as default
     let pending_tx = pending_tx.interval(Duration::from_secs(1));
     let potential_error = GravityError::GravityContractError(format!(
         "Did not receive transaction receipt when deploying ERC-20 {}: {}",
-        erc20_symbol, tx_hash
+        erc20_symbol, format_eth_hash(tx_hash)
     ));
 
     if let Some(timeout) = wait_timeout {

--- a/orchestrator/ethereum_gravity/src/deploy_erc20.rs
+++ b/orchestrator/ethereum_gravity/src/deploy_erc20.rs
@@ -36,9 +36,13 @@ pub async fn deploy_erc20(
     }
     let gas = (gas_as_f64.unwrap() * gas_multiplier) as u128;
 
+    // TODO(bolten): it seems like a bug in ethers will replace manually set gas limits with
+    // a gas estimate if no access list is defined for EIP1559 transactions, so we're forcing a
+    // legacy transaction here to allow for the multiplier to take effect
     let contract_call = contract_call
         .gas_price(gas_price)
-        .gas(gas);
+        .gas(gas)
+        .legacy();
 
     let pending_tx = contract_call.send().await?;
     let tx_hash = *pending_tx;

--- a/orchestrator/gorc/src/commands/deploy/erc20.rs
+++ b/orchestrator/gorc/src/commands/deploy/erc20.rs
@@ -5,7 +5,7 @@ use ethers::prelude::*;
 use gravity_proto::gravity::{DenomToErc20ParamsRequest, DenomToErc20Request};
 use gravity_utils::{
     connection_prep::{check_for_eth, create_rpc_connections},
-    ethereum::downcast_to_u64,
+    ethereum::{downcast_to_u64, format_eth_hash},
 };
 use std::convert::TryFrom;
 use std::process::exit;
@@ -99,7 +99,8 @@ impl Erc20 {
         .await
         .expect("Could not deploy ERC20");
 
-        println!("We have deployed ERC20 contract {}, waiting to see if the Cosmos chain choses to adopt it", res);
+        println!("We have deployed ERC20 contract at tx hash {}, waiting to see if the Cosmos chain choses to adopt it",
+            format_eth_hash(res));
 
         match tokio::time::timeout(Duration::from_secs(100), async {
             loop {

--- a/orchestrator/gorc/src/commands/deploy/erc20.rs
+++ b/orchestrator/gorc/src/commands/deploy/erc20.rs
@@ -19,6 +19,9 @@ pub struct Erc20 {
 
     #[clap(short, long)]
     ethereum_key: String,
+
+    #[clap(short, long, default_value_t = 1.0)]
+    gas_multiplier: f64,
 }
 
 impl Runnable for Erc20 {
@@ -90,6 +93,7 @@ impl Erc20 {
             u8::try_from(res.erc20_decimals).unwrap(),
             contract_address,
             Some(timeout),
+            self.gas_multiplier,
             eth_client.clone(),
         )
         .await

--- a/orchestrator/gravity_utils/src/ethereum.rs
+++ b/orchestrator/gravity_utils/src/ethereum.rs
@@ -39,6 +39,10 @@ pub fn format_eth_address(address: EthAddress) -> String {
     format!("0x{}", bytes_to_hex_str(address.as_bytes()))
 }
 
+pub fn format_eth_hash(hash: H256) -> String {
+    format!("0x{}", bytes_to_hex_str(hash.as_bytes()))
+}
+
 pub fn bytes_to_hex_str(bytes: &[u8]) -> String {
     bytes
         .iter()

--- a/orchestrator/gravity_utils/src/ethereum.rs
+++ b/orchestrator/gravity_utils/src/ethereum.rs
@@ -14,6 +14,13 @@ pub fn downcast_to_f32(input: U256) -> Option<f32> {
     }
 }
 
+pub fn downcast_to_f64(input: U256) -> Option<f64> {
+    match panic::catch_unwind(|| input.as_u128() as f64) {
+        Ok(downcasted) => Some(downcasted),
+        Err(_) => None,
+    }
+}
+
 pub fn downcast_to_u64(input: U256) -> Option<u64> {
     match panic::catch_unwind(|| input.as_u64()) {
         Ok(downcasted) => Some(downcasted),

--- a/orchestrator/test_runner/src/happy_path_v2.rs
+++ b/orchestrator/test_runner/src/happy_path_v2.rs
@@ -53,6 +53,7 @@ pub async fn happy_path_test_v2(
         6,
         gravity_address,
         Some(TOTAL_TIMEOUT),
+        1.0,
         eth_client.clone(),
     )
     .await


### PR DESCRIPTION
Add the option for a gas multiplier when deploying an ERC20. Contains some debugging cruft that will be removed before this is converted from a draft.