### PR TITLE
Fix the eth-to-cosmos command

### DIFF
--- a/orchestrator/ethereum_gravity/src/send_to_cosmos.rs
+++ b/orchestrator/ethereum_gravity/src/send_to_cosmos.rs
@@ -55,7 +55,8 @@ pub async fn send_to_cosmos(
 
     let contract_call = Gravity::new(gravity_contract, eth_client.clone())
         .send_to_cosmos(erc20, cosmos_dest_address_bytes_slice, amount)
-        .gas(SEND_TO_COSMOS_GAS_LIMIT);
+        .gas(SEND_TO_COSMOS_GAS_LIMIT)
+        .legacy();
 
     let pending_tx = contract_call.send().await?;
     let tx_hash = *pending_tx;

--- a/orchestrator/gorc/src/commands/eth_to_cosmos.rs
+++ b/orchestrator/gorc/src/commands/eth_to_cosmos.rs
@@ -64,7 +64,7 @@ impl Runnable for EthToCosmosCmd {
             check_for_eth(ethereum_address, eth_client.clone()).await;
 
             let init_amount = self.args.get(4).expect("amount is required");
-            let amount: U256 = init_amount.parse().unwrap();
+            let amount = U256::from_dec_str(init_amount).expect("cannot parse amount as U256");
 
             let erc20_balance =
                 get_erc20_balance(erc20_address, ethereum_address, eth_client.clone())
@@ -72,8 +72,8 @@ impl Runnable for EthToCosmosCmd {
                     .expect("Failed to get balance, check ERC20 contract address");
 
             let times = self.args.get(5).expect("times is required");
-            let times_usize = times.parse::<usize>().expect("cannot parse times");
-            let times_u256 = U256::from_dec_str(times).expect("cannot parse times");
+            let times_usize = times.parse::<usize>().expect("cannot parse times as usize");
+            let times_u256 = U256::from_dec_str(times).expect("cannot parse times as U256");
 
             if erc20_balance == 0u8.into() {
                 panic!(


### PR DESCRIPTION
Fix argument parsing (amount needs to be parsed as a decimal string into U256) and force a legacy transaction since the manually set gas limit isn't respected in EIP1559 transactions.