### PR TITLE
Fix and test delegate genesis export

### DIFF
--- a/module/x/gravity/keeper/genesis.go
+++ b/module/x/gravity/keeper/genesis.go
@@ -157,6 +157,10 @@ func ExportGenesis(ctx sdk.Context, k Keeper) types.GenesisState {
 		return false
 	})
 
+	for _, delegate := range delegates {
+		delegate.EthSignature = []byte("unused")
+	}
+
 	return types.GenesisState{
 		Params:                     &p,
 		LastObservedEventNonce:     lastobserved,

--- a/module/x/gravity/keeper/genesis.go
+++ b/module/x/gravity/keeper/genesis.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -21,10 +23,10 @@ func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) {
 	for _, evr := range data.EthereumEventVoteRecords {
 		event, err := types.UnpackEvent(evr.Event)
 		if err != nil {
-			panic("couldn't cast to event")
+			panic(fmt.Sprintf("couldn't cast to event: %s", err))
 		}
 		if err := event.Validate(); err != nil {
-			panic("invalid event in genesis")
+			panic(fmt.Sprintf("invalid event in genesis: %s", err))
 		}
 		k.setEthereumEventVoteRecord(ctx, event.GetEventNonce(), event.Hash(), evr)
 	}
@@ -50,7 +52,7 @@ func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) {
 	// reset delegate keys in state
 	for _, keys := range data.DelegateKeys {
 		if err := keys.ValidateBasic(); err != nil {
-			panic("Invalid delegate key in Genesis!")
+			panic(fmt.Sprintf("Invalid delegate key in Genesis: %s", err))
 		}
 
 		val, _ := sdk.ValAddressFromBech32(keys.ValidatorAddress)
@@ -73,7 +75,7 @@ func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) {
 	for _, ota := range data.OutgoingTxs {
 		otx, err := types.UnpackOutgoingTx(ota)
 		if err != nil {
-			panic("invalid outgoing tx any in genesis file")
+			panic(fmt.Sprintf("invalid outgoing tx any in genesis file: %s", err))
 		}
 		k.SetOutgoingTx(ctx, otx)
 	}
@@ -82,7 +84,7 @@ func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) {
 	for _, confa := range data.Confirmations {
 		conf, err := types.UnpackConfirmation(confa)
 		if err != nil {
-			panic("invalid etheruem signature in genesis")
+			panic(fmt.Sprintf("invalid etheruem signature in genesis: %s", err))
 		}
 		// TODO: not currently an easy way to get the validator address from the
 		// etherum address here. once we implement the third index for keys

--- a/module/x/gravity/keeper/genesis.go
+++ b/module/x/gravity/keeper/genesis.go
@@ -159,6 +159,7 @@ func ExportGenesis(ctx sdk.Context, k Keeper) types.GenesisState {
 		return false
 	})
 
+	// this will marshal into "dW51c2Vk" as []byte will be encoded as base64
 	for _, delegate := range delegates {
 		delegate.EthSignature = []byte("unused")
 	}

--- a/module/x/gravity/keeper/genesis_test.go
+++ b/module/x/gravity/keeper/genesis_test.go
@@ -21,6 +21,7 @@ func TestExportAndImport(t *testing.T) {
 
 	keeper.setValidatorEthereumAddress(ctx, valAddr, ethAddr)
 	keeper.setEthereumOrchestratorAddress(ctx, ethAddr, orchAddr)
+	keeper.SetOrchestratorValidatorAddress(ctx, valAddr, orchAddr)
 
 	exportedGenesis := ExportGenesis(ctx, keeper)
 	newEnv := CreateTestEnv(t)
@@ -31,4 +32,5 @@ func TestExportAndImport(t *testing.T) {
 
 	assert.Equal(t, newKeeper.GetValidatorEthereumAddress(newCtx, valAddr), ethAddr)
 	assert.Equal(t, newKeeper.GetEthereumOrchestratorAddress(newCtx, ethAddr), orchAddr)
+	assert.Equal(t, newKeeper.GetOrchestratorValidatorAddress(newCtx, orchAddr), valAddr)
 }

--- a/module/x/gravity/keeper/genesis_test.go
+++ b/module/x/gravity/keeper/genesis_test.go
@@ -1,0 +1,34 @@
+package keeper
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// for the moment this is only testing delegate keys being set, but it would be good to make
+// this test more expansive
+func TestExportAndImport(t *testing.T) {
+	env := CreateTestEnv(t)
+	ctx := env.Context
+	keeper := env.GravityKeeper
+
+	valAddr, _ := sdk.ValAddressFromBech32("cosmosvaloper13yfm8as7y0mzsxqkfmk5jvgm45aez0u24jk95z")
+	orchAddr, _ := sdk.AccAddressFromBech32("cosmos1h706wwrghfpydyh735aet8aluhf95dqj0psgyf")
+	ethAddr := common.BytesToAddress([]byte("0xFDb0aaBD40774BBF3068Bf29E8b0a6C88BE26F83"))
+
+	keeper.setValidatorEthereumAddress(ctx, valAddr, ethAddr)
+	keeper.setEthereumOrchestratorAddress(ctx, ethAddr, orchAddr)
+
+	exportedGenesis := ExportGenesis(ctx, keeper)
+	newEnv := CreateTestEnv(t)
+	newCtx := newEnv.Context
+	newKeeper := newEnv.GravityKeeper
+
+	InitGenesis(newCtx, newKeeper, exportedGenesis)
+
+	assert.Equal(t, newKeeper.GetValidatorEthereumAddress(newCtx, valAddr), ethAddr)
+	assert.Equal(t, newKeeper.GetEthereumOrchestratorAddress(newCtx, ethAddr), orchAddr)
+}

--- a/module/x/gravity/types/genesis.go
+++ b/module/x/gravity/types/genesis.go
@@ -100,6 +100,13 @@ func (s GenesisState) ValidateBasic() error {
 	if err := s.Params.ValidateBasic(); err != nil {
 		return sdkerrors.Wrap(err, "params")
 	}
+	if len(s.DelegateKeys) != 0 {
+		for _, delegateKey := range s.DelegateKeys {
+			if err := delegateKey.ValidateBasic(); err != nil {
+				return sdkerrors.Wrap(err, "delegates")
+			}
+		}
+	}
 	return nil
 }
 

--- a/module/x/gravity/types/genesis_test.go
+++ b/module/x/gravity/types/genesis_test.go
@@ -26,12 +26,10 @@ func TestGenesisStateValidate(t *testing.T) {
 			Params: DefaultParams(),
 			DelegateKeys: []*MsgDelegateKeys{
 				{
-					// note: the "valid" EthSignature here is simply the correct format, it is not a signature from a private key represented
-					// by the above cosmos address, but genesis isn't currently validating that anyway
-					ValidatorAddress:    "cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4",
-					OrchestratorAddress: "cosmos1g0etv93428tvxqftnmj25jn06mz6dtdasj5nz7",
-					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
-					EthSignature:        []byte("0x2471d20201d38a6d8f5301be45560161d770f8ca8642ac45a1eb5c82fd853a8670fb6f18aaedffd7fcf27bba62d29b782a1c12059ab43b79d7d2d727f596d7701c"),
+					ValidatorAddress:    "cosmosvaloper13yfm8as7y0mzsxqkfmk5jvgm45aez0u24jk95z",
+					OrchestratorAddress: "cosmos1h706wwrghfpydyh735aet8aluhf95dqj0psgyf",
+					EthereumAddress:     "0xFDb0aaBD40774BBF3068Bf29E8b0a6C88BE26F83",
+					EthSignature:        []byte("0xa2f643b5b919050eb4e200bae900d16fd28adca4d727fb7cc1c68f2517e601d0355340ee0913b1e3b5a5837fbd795857a004e0333913cfb7c59e159ff02115b01c"),
 				},
 			},
 		}, expErr: false},
@@ -39,9 +37,9 @@ func TestGenesisStateValidate(t *testing.T) {
 			Params: DefaultParams(),
 			DelegateKeys: []*MsgDelegateKeys{
 				{
-					ValidatorAddress:    "cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4",
-					OrchestratorAddress: "cosmos1g0etv93428tvxqftnmj25jn06mz6dtdasj5nz7",
-					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
+					ValidatorAddress:    "cosmosvaloper13yfm8as7y0mzsxqkfmk5jvgm45aez0u24jk95z",
+					OrchestratorAddress: "cosmos1h706wwrghfpydyh735aet8aluhf95dqj0psgyf",
+					EthereumAddress:     "0xFDb0aaBD40774BBF3068Bf29E8b0a6C88BE26F83",
 					EthSignature:        []byte("unused"), // this will marshal into "dW51c2Vk" as []byte will be encoded as base64
 				},
 			},
@@ -50,9 +48,9 @@ func TestGenesisStateValidate(t *testing.T) {
 			Params: DefaultParams(),
 			DelegateKeys: []*MsgDelegateKeys{
 				{
-					ValidatorAddress:    "cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4",
-					OrchestratorAddress: "cosmos1g0etv93428tvxqftnmj25jn06mz6dtdasj5nz7",
-					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
+					ValidatorAddress:    "cosmosvaloper13yfm8as7y0mzsxqkfmk5jvgm45aez0u24jk95z",
+					OrchestratorAddress: "cosmos1h706wwrghfpydyh735aet8aluhf95dqj0psgyf",
+					EthereumAddress:     "0xFDb0aaBD40774BBF3068Bf29E8b0a6C88BE26F83",
 					EthSignature:        nilByteSlice,
 				},
 			},
@@ -62,9 +60,9 @@ func TestGenesisStateValidate(t *testing.T) {
 			DelegateKeys: []*MsgDelegateKeys{
 				{
 					ValidatorAddress:    "cosmosvaloper1wrong",
-					OrchestratorAddress: "cosmos1g0etv93428tvxqftnmj25jn06mz6dtdasj5nz7",
-					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
-					EthSignature:        []byte("0x2471d20201d38a6d8f5301be45560161d770f8ca8642ac45a1eb5c82fd853a8670fb6f18aaedffd7fcf27bba62d29b782a1c12059ab43b79d7d2d727f596d7701c"),
+					OrchestratorAddress: "cosmos1h706wwrghfpydyh735aet8aluhf95dqj0psgyf",
+					EthereumAddress:     "0xFDb0aaBD40774BBF3068Bf29E8b0a6C88BE26F83",
+					EthSignature:        []byte("0xa2f643b5b919050eb4e200bae900d16fd28adca4d727fb7cc1c68f2517e601d0355340ee0913b1e3b5a5837fbd795857a004e0333913cfb7c59e159ff02115b01c"),
 				},
 			},
 		}, expErr: true},
@@ -72,10 +70,10 @@ func TestGenesisStateValidate(t *testing.T) {
 			Params: DefaultParams(),
 			DelegateKeys: []*MsgDelegateKeys{
 				{
-					ValidatorAddress:    "cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4",
+					ValidatorAddress:    "cosmosvaloper13yfm8as7y0mzsxqkfmk5jvgm45aez0u24jk95z",
 					OrchestratorAddress: "cosmos1wrong",
-					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
-					EthSignature:        []byte("0x2471d20201d38a6d8f5301be45560161d770f8ca8642ac45a1eb5c82fd853a8670fb6f18aaedffd7fcf27bba62d29b782a1c12059ab43b79d7d2d727f596d7701c"),
+					EthereumAddress:     "0xFDb0aaBD40774BBF3068Bf29E8b0a6C88BE26F83",
+					EthSignature:        []byte("0xa2f643b5b919050eb4e200bae900d16fd28adca4d727fb7cc1c68f2517e601d0355340ee0913b1e3b5a5837fbd795857a004e0333913cfb7c59e159ff02115b01c"),
 				},
 			},
 		}, expErr: true},
@@ -83,10 +81,10 @@ func TestGenesisStateValidate(t *testing.T) {
 			Params: DefaultParams(),
 			DelegateKeys: []*MsgDelegateKeys{
 				{
-					ValidatorAddress:    "cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4",
-					OrchestratorAddress: "cosmos1g0etv93428tvxqftnmj25jn06mz6dtdasj5nz7",
+					ValidatorAddress:    "cosmosvaloper13yfm8as7y0mzsxqkfmk5jvgm45aez0u24jk95z",
+					OrchestratorAddress: "cosmos1h706wwrghfpydyh735aet8aluhf95dqj0psgyf",
 					EthereumAddress:     "0xdeadbeef",
-					EthSignature:        []byte("0x2471d20201d38a6d8f5301be45560161d770f8ca8642ac45a1eb5c82fd853a8670fb6f18aaedffd7fcf27bba62d29b782a1c12059ab43b79d7d2d727f596d7701c"),
+					EthSignature:        []byte("0xa2f643b5b919050eb4e200bae900d16fd28adca4d727fb7cc1c68f2517e601d0355340ee0913b1e3b5a5837fbd795857a004e0333913cfb7c59e159ff02115b01c"),
 				},
 			},
 		}, expErr: true},

--- a/module/x/gravity/types/genesis_test.go
+++ b/module/x/gravity/types/genesis_test.go
@@ -3,10 +3,15 @@ package types
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGenesisStateValidate(t *testing.T) {
+	sdk.GetConfig().SetBech32PrefixForValidator("sommvaloper", "sommvaloperpub")
+	sdk.GetConfig().SetBech32PrefixForAccount("somm", "sommpub")
+	sdk.GetConfig().SetBech32PrefixForConsensusNode("sommcons", "sommconspub")
+
 	var nilByteSlice []byte
 	specs := map[string]struct {
 		src    *GenesisState

--- a/module/x/gravity/types/genesis_test.go
+++ b/module/x/gravity/types/genesis_test.go
@@ -3,15 +3,10 @@ package types
 import (
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGenesisStateValidate(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForValidator("sommvaloper", "sommvaloperpub")
-	sdk.GetConfig().SetBech32PrefixForAccount("somm", "sommpub")
-	sdk.GetConfig().SetBech32PrefixForConsensusNode("sommcons", "sommconspub")
-
 	var nilByteSlice []byte
 	specs := map[string]struct {
 		src    *GenesisState
@@ -31,8 +26,8 @@ func TestGenesisStateValidate(t *testing.T) {
 			Params: DefaultParams(),
 			DelegateKeys: []*MsgDelegateKeys{
 				{
-					ValidatorAddress:    "sommvaloper1w4lcqzsrfgfwrgd386v9n6frj9p66k4xazvsqn",
-					OrchestratorAddress: "somm1ht877l3pgqjkalxwtvmydr65jnde3p4g7vxq5t",
+					ValidatorAddress:    "cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4",
+					OrchestratorAddress: "cosmos1g0etv93428tvxqftnmj25jn06mz6dtdasj5nz7",
 					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
 					EthSignature:        []byte("xIm9M32dXl7II8c72qXS/x9xVQMbX9sHVkuigxSmspNhSnEc2dLe6YDn/+Yi3VAOwXKh8zUBSHMplQSEuOY1zhw="),
 				},
@@ -42,8 +37,8 @@ func TestGenesisStateValidate(t *testing.T) {
 			Params: DefaultParams(),
 			DelegateKeys: []*MsgDelegateKeys{
 				{
-					ValidatorAddress:    "sommvaloper1w4lcqzsrfgfwrgd386v9n6frj9p66k4xazvsqn",
-					OrchestratorAddress: "somm1ht877l3pgqjkalxwtvmydr65jnde3p4g7vxq5t",
+					ValidatorAddress:    "cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4",
+					OrchestratorAddress: "cosmos1g0etv93428tvxqftnmj25jn06mz6dtdasj5nz7",
 					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
 					EthSignature:        []byte("unused"),
 				},
@@ -53,8 +48,8 @@ func TestGenesisStateValidate(t *testing.T) {
 			Params: DefaultParams(),
 			DelegateKeys: []*MsgDelegateKeys{
 				{
-					ValidatorAddress:    "sommvaloper1w4lcqzsrfgfwrgd386v9n6frj9p66k4xazvsqn",
-					OrchestratorAddress: "somm1ht877l3pgqjkalxwtvmydr65jnde3p4g7vxq5t",
+					ValidatorAddress:    "cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4",
+					OrchestratorAddress: "cosmos1g0etv93428tvxqftnmj25jn06mz6dtdasj5nz7",
 					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
 					EthSignature:        nilByteSlice,
 				},
@@ -64,8 +59,8 @@ func TestGenesisStateValidate(t *testing.T) {
 			Params: DefaultParams(),
 			DelegateKeys: []*MsgDelegateKeys{
 				{
-					ValidatorAddress:    "sommvaloper1wrong",
-					OrchestratorAddress: "somm1ht877l3pgqjkalxwtvmydr65jnde3p4g7vxq5t",
+					ValidatorAddress:    "cosmosvaloper1wrong",
+					OrchestratorAddress: "cosmos1g0etv93428tvxqftnmj25jn06mz6dtdasj5nz7",
 					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
 					EthSignature:        []byte("xIm9M32dXl7II8c72qXS/x9xVQMbX9sHVkuigxSmspNhSnEc2dLe6YDn/+Yi3VAOwXKh8zUBSHMplQSEuOY1zhw="),
 				},
@@ -75,8 +70,8 @@ func TestGenesisStateValidate(t *testing.T) {
 			Params: DefaultParams(),
 			DelegateKeys: []*MsgDelegateKeys{
 				{
-					ValidatorAddress:    "sommvaloper1w4lcqzsrfgfwrgd386v9n6frj9p66k4xazvsqn",
-					OrchestratorAddress: "somm1wrong",
+					ValidatorAddress:    "cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4",
+					OrchestratorAddress: "cosmos1wrong",
 					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
 					EthSignature:        []byte("xIm9M32dXl7II8c72qXS/x9xVQMbX9sHVkuigxSmspNhSnEc2dLe6YDn/+Yi3VAOwXKh8zUBSHMplQSEuOY1zhw="),
 				},
@@ -86,8 +81,8 @@ func TestGenesisStateValidate(t *testing.T) {
 			Params: DefaultParams(),
 			DelegateKeys: []*MsgDelegateKeys{
 				{
-					ValidatorAddress:    "sommvaloper1w4lcqzsrfgfwrgd386v9n6frj9p66k4xazvsqn",
-					OrchestratorAddress: "somm1ht877l3pgqjkalxwtvmydr65jnde3p4g7vxq5t",
+					ValidatorAddress:    "cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4",
+					OrchestratorAddress: "cosmos1g0etv93428tvxqftnmj25jn06mz6dtdasj5nz7",
 					EthereumAddress:     "0xdeadbeef",
 					EthSignature:        []byte("xIm9M32dXl7II8c72qXS/x9xVQMbX9sHVkuigxSmspNhSnEc2dLe6YDn/+Yi3VAOwXKh8zUBSHMplQSEuOY1zhw="),
 				},

--- a/module/x/gravity/types/genesis_test.go
+++ b/module/x/gravity/types/genesis_test.go
@@ -40,7 +40,7 @@ func TestGenesisStateValidate(t *testing.T) {
 					ValidatorAddress:    "cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4",
 					OrchestratorAddress: "cosmos1g0etv93428tvxqftnmj25jn06mz6dtdasj5nz7",
 					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
-					EthSignature:        []byte("unused"),
+					EthSignature:        []byte("unused"), // this will marshal into "dW51c2Vk" as []byte will be encoded as base64
 				},
 			},
 		}, expErr: false},

--- a/module/x/gravity/types/genesis_test.go
+++ b/module/x/gravity/types/genesis_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestGenesisStateValidate(t *testing.T) {
+	var nilByteSlice []byte
 	specs := map[string]struct {
 		src    *GenesisState
 		expErr bool
@@ -19,6 +20,72 @@ func TestGenesisStateValidate(t *testing.T) {
 				ContractSourceHash:    "laksdjflasdkfja",
 				BridgeEthereumAddress: "invalid-eth-address",
 				BridgeChainId:         3279089,
+			},
+		}, expErr: true},
+		"valid delegate": {src: &GenesisState{
+			Params: DefaultParams(),
+			DelegateKeys: []*MsgDelegateKeys{
+				{
+					ValidatorAddress:    "sommvaloper1w4lcqzsrfgfwrgd386v9n6frj9p66k4xazvsqn",
+					OrchestratorAddress: "somm1ht877l3pgqjkalxwtvmydr65jnde3p4g7vxq5t",
+					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
+					EthSignature:        []byte("xIm9M32dXl7II8c72qXS/x9xVQMbX9sHVkuigxSmspNhSnEc2dLe6YDn/+Yi3VAOwXKh8zUBSHMplQSEuOY1zhw="),
+				},
+			},
+		}, expErr: false},
+		"valid delegate with placeholder signature": {src: &GenesisState{
+			Params: DefaultParams(),
+			DelegateKeys: []*MsgDelegateKeys{
+				{
+					ValidatorAddress:    "sommvaloper1w4lcqzsrfgfwrgd386v9n6frj9p66k4xazvsqn",
+					OrchestratorAddress: "somm1ht877l3pgqjkalxwtvmydr65jnde3p4g7vxq5t",
+					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
+					EthSignature:        []byte("unused"),
+				},
+			},
+		}, expErr: false},
+		"valid delegate with nil signature": {src: &GenesisState{
+			Params: DefaultParams(),
+			DelegateKeys: []*MsgDelegateKeys{
+				{
+					ValidatorAddress:    "sommvaloper1w4lcqzsrfgfwrgd386v9n6frj9p66k4xazvsqn",
+					OrchestratorAddress: "somm1ht877l3pgqjkalxwtvmydr65jnde3p4g7vxq5t",
+					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
+					EthSignature:        nilByteSlice,
+				},
+			},
+		}, expErr: true},
+		"delegate with bad validator address": {src: &GenesisState{
+			Params: DefaultParams(),
+			DelegateKeys: []*MsgDelegateKeys{
+				{
+					ValidatorAddress:    "sommvaloper1wrong",
+					OrchestratorAddress: "somm1ht877l3pgqjkalxwtvmydr65jnde3p4g7vxq5t",
+					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
+					EthSignature:        []byte("xIm9M32dXl7II8c72qXS/x9xVQMbX9sHVkuigxSmspNhSnEc2dLe6YDn/+Yi3VAOwXKh8zUBSHMplQSEuOY1zhw="),
+				},
+			},
+		}, expErr: true},
+		"delegate with bad orchestrator address": {src: &GenesisState{
+			Params: DefaultParams(),
+			DelegateKeys: []*MsgDelegateKeys{
+				{
+					ValidatorAddress:    "sommvaloper1w4lcqzsrfgfwrgd386v9n6frj9p66k4xazvsqn",
+					OrchestratorAddress: "somm1wrong",
+					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
+					EthSignature:        []byte("xIm9M32dXl7II8c72qXS/x9xVQMbX9sHVkuigxSmspNhSnEc2dLe6YDn/+Yi3VAOwXKh8zUBSHMplQSEuOY1zhw="),
+				},
+			},
+		}, expErr: true},
+		"delegate with bad eth address": {src: &GenesisState{
+			Params: DefaultParams(),
+			DelegateKeys: []*MsgDelegateKeys{
+				{
+					ValidatorAddress:    "sommvaloper1w4lcqzsrfgfwrgd386v9n6frj9p66k4xazvsqn",
+					OrchestratorAddress: "somm1ht877l3pgqjkalxwtvmydr65jnde3p4g7vxq5t",
+					EthereumAddress:     "0xdeadbeef",
+					EthSignature:        []byte("xIm9M32dXl7II8c72qXS/x9xVQMbX9sHVkuigxSmspNhSnEc2dLe6YDn/+Yi3VAOwXKh8zUBSHMplQSEuOY1zhw="),
+				},
 			},
 		}, expErr: true},
 	}

--- a/module/x/gravity/types/genesis_test.go
+++ b/module/x/gravity/types/genesis_test.go
@@ -26,10 +26,12 @@ func TestGenesisStateValidate(t *testing.T) {
 			Params: DefaultParams(),
 			DelegateKeys: []*MsgDelegateKeys{
 				{
+					// note: the "valid" EthSignature here is simply the correct format, it is not a signature from a private key represented
+					// by the above cosmos address, but genesis isn't currently validating that anyway
 					ValidatorAddress:    "cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4",
 					OrchestratorAddress: "cosmos1g0etv93428tvxqftnmj25jn06mz6dtdasj5nz7",
 					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
-					EthSignature:        []byte("xIm9M32dXl7II8c72qXS/x9xVQMbX9sHVkuigxSmspNhSnEc2dLe6YDn/+Yi3VAOwXKh8zUBSHMplQSEuOY1zhw="),
+					EthSignature:        []byte("0x2471d20201d38a6d8f5301be45560161d770f8ca8642ac45a1eb5c82fd853a8670fb6f18aaedffd7fcf27bba62d29b782a1c12059ab43b79d7d2d727f596d7701c"),
 				},
 			},
 		}, expErr: false},
@@ -62,7 +64,7 @@ func TestGenesisStateValidate(t *testing.T) {
 					ValidatorAddress:    "cosmosvaloper1wrong",
 					OrchestratorAddress: "cosmos1g0etv93428tvxqftnmj25jn06mz6dtdasj5nz7",
 					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
-					EthSignature:        []byte("xIm9M32dXl7II8c72qXS/x9xVQMbX9sHVkuigxSmspNhSnEc2dLe6YDn/+Yi3VAOwXKh8zUBSHMplQSEuOY1zhw="),
+					EthSignature:        []byte("0x2471d20201d38a6d8f5301be45560161d770f8ca8642ac45a1eb5c82fd853a8670fb6f18aaedffd7fcf27bba62d29b782a1c12059ab43b79d7d2d727f596d7701c"),
 				},
 			},
 		}, expErr: true},
@@ -73,7 +75,7 @@ func TestGenesisStateValidate(t *testing.T) {
 					ValidatorAddress:    "cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4",
 					OrchestratorAddress: "cosmos1wrong",
 					EthereumAddress:     "0x494eeff8848254C4fdd5B529FC6E751Ab34597A6",
-					EthSignature:        []byte("xIm9M32dXl7II8c72qXS/x9xVQMbX9sHVkuigxSmspNhSnEc2dLe6YDn/+Yi3VAOwXKh8zUBSHMplQSEuOY1zhw="),
+					EthSignature:        []byte("0x2471d20201d38a6d8f5301be45560161d770f8ca8642ac45a1eb5c82fd853a8670fb6f18aaedffd7fcf27bba62d29b782a1c12059ab43b79d7d2d727f596d7701c"),
 				},
 			},
 		}, expErr: true},
@@ -84,7 +86,7 @@ func TestGenesisStateValidate(t *testing.T) {
 					ValidatorAddress:    "cosmosvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6z3plt4",
 					OrchestratorAddress: "cosmos1g0etv93428tvxqftnmj25jn06mz6dtdasj5nz7",
 					EthereumAddress:     "0xdeadbeef",
-					EthSignature:        []byte("xIm9M32dXl7II8c72qXS/x9xVQMbX9sHVkuigxSmspNhSnEc2dLe6YDn/+Yi3VAOwXKh8zUBSHMplQSEuOY1zhw="),
+					EthSignature:        []byte("0x2471d20201d38a6d8f5301be45560161d770f8ca8642ac45a1eb5c82fd853a8670fb6f18aaedffd7fcf27bba62d29b782a1c12059ab43b79d7d2d727f596d7701c"),
 				},
 			},
 		}, expErr: true},


### PR DESCRIPTION
Use a placeholder value for `EthSignature` in `DelegateKeys` when exporting since it will not be present in the keeper and will instead return `null`. Additionally, add testing to confirm `DelegateKeys` validation is working as expected.