### PR TITLE
Update gorc version string

### DIFF
--- a/orchestrator/gorc/Cargo.toml
+++ b/orchestrator/gorc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gorc"
 authors = []
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 rust-version = "1.56"
 


### PR DESCRIPTION
Latest tag still reports `v0.3.8`