### PR TITLE
Fix solidity dev dependencies

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -62,7 +62,7 @@
   },
   "resolutions": {
     "web3": "1.6.1",
-    "uuid": "8.3.2"
+    "uuid": "7.0.3"
   },
   "dependencies": {
     "@cosmjs/stargate": "^0.25.3",


### PR DESCRIPTION
Following this issue https://github.com/PeggyJV/gravity-bridge/issues/354 

Open a PR to fix this upstream.

We might need also to consider updating all dependencies to their latest version