### PR TITLE
Fix outstanding staticcheck warnings

### DIFF
--- a/module/cmd/gravity/cmd/genaccounts.go
+++ b/module/cmd/gravity/cmd/genaccounts.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/server"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -40,8 +39,7 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-			depCdc := clientCtx.Codec
-			cdc := depCdc.(codec.Codec)
+			cdc := clientCtx.Codec
 
 			serverCtx := server.GetServerContextFromCmd(cmd)
 			config := serverCtx.Config
@@ -148,7 +146,7 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 
 			appState[authtypes.ModuleName] = authGenStateBz
 
-			bankGenState := banktypes.GetGenesisStateFromAppState(depCdc, appState)
+			bankGenState := banktypes.GetGenesisStateFromAppState(cdc, appState)
 			bankGenState.Balances = append(bankGenState.Balances, balances)
 			bankGenState.Balances = banktypes.SanitizeGenesisBalances(bankGenState.Balances)
 

--- a/module/cmd/gravity/cmd/gentx.go
+++ b/module/cmd/gravity/cmd/gentx.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/version"
 	authclient "github.com/cosmos/cosmos-sdk/x/auth/client"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankexported "github.com/cosmos/cosmos-sdk/x/bank/exported"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	"github.com/cosmos/cosmos-sdk/x/genutil/types"
@@ -527,33 +526,4 @@ func CollectTxs(cdc codec.JSONCodec, txJSONDecoder sdk.TxDecoder, moniker, genTx
 	persistentPeers = strings.Join(addressesIPs, ",")
 
 	return appGenTxs, persistentPeers, nil
-}
-
-func validateAccountPresentInGenesis(
-	appGenesisState map[string]json.RawMessage, genBalIterator authtypes.GenesisAccountIterator,
-	addr sdk.Address, coins sdk.Coins, cdc codec.Codec,
-) error {
-
-	accountIsInGenesis := false
-
-	genBalIterator.IterateGenesisAccounts(cdc, appGenesisState,
-		func(acc authtypes.AccountI) (stop bool) {
-			accAddress := acc.GetAddress()
-
-			// ensure that account is in genesis
-			if accAddress.Equals(addr) {
-				// ensure account contains enough funds of default bond denom
-				accountIsInGenesis = true
-				return true
-			}
-
-			return false
-		},
-	)
-
-	if !accountIsInGenesis {
-		return fmt.Errorf("account %s does not have a balance in the genesis state", addr)
-	}
-
-	return nil
 }

--- a/module/x/gravity/client/cli/query.go
+++ b/module/x/gravity/client/cli/query.go
@@ -820,14 +820,6 @@ func parseContractAddress(s string) (string, error) {
 	return s, nil
 }
 
-func parseCount(s string) (int64, error) {
-	count, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("count %s not a valid int, please input a valid count", s)
-	}
-	return count, nil
-}
-
 func parseNonce(s string) (uint64, error) {
 	nonce, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {

--- a/module/x/gravity/handler_test.go
+++ b/module/x/gravity/handler_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
-	ethCrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/peggyjv/gravity-bridge/module/app"
 	"github.com/peggyjv/gravity-bridge/module/x/gravity"
 	"github.com/peggyjv/gravity-bridge/module/x/gravity/keeper"
@@ -287,8 +286,10 @@ func TestMsgSubmitEthreumEventSendToCosmosMultiValidator(t *testing.T) {
 }
 
 func TestMsgSetDelegateAddresses(t *testing.T) {
-	ethPrivKey, err := ethCrypto.GenerateKey()
-	ethPrivKey2, err := ethCrypto.GenerateKey()
+	ethPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	ethPrivKey2, err := crypto.GenerateKey()
+	require.NoError(t, err)
 
 	var (
 		ethAddress                    = crypto.PubkeyToAddress(ethPrivKey.PublicKey)

--- a/module/x/gravity/keeper/msg_server_test.go
+++ b/module/x/gravity/keeper/msg_server_test.go
@@ -9,14 +9,13 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
-	ethCrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/peggyjv/gravity-bridge/module/x/gravity/types"
 )
 
 func TestMsgServer_SubmitEthereumSignature(t *testing.T) {
-	ethPrivKey, err := ethCrypto.GenerateKey()
+	ethPrivKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
 	var (
@@ -75,7 +74,7 @@ func TestMsgServer_SubmitEthereumSignature(t *testing.T) {
 }
 
 func TestMsgServer_SendToEthereum(t *testing.T) {
-	ethPrivKey, err := ethCrypto.GenerateKey()
+	ethPrivKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
 	var (
@@ -139,7 +138,7 @@ func TestMsgServer_SendToEthereum(t *testing.T) {
 }
 
 func TestMsgServer_CancelSendToEthereum(t *testing.T) {
-	ethPrivKey, err := ethCrypto.GenerateKey()
+	ethPrivKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
 	var (
@@ -210,7 +209,7 @@ func TestMsgServer_CancelSendToEthereum(t *testing.T) {
 }
 
 func TestMsgServer_RequestBatchTx(t *testing.T) {
-	ethPrivKey, err := ethCrypto.GenerateKey()
+	ethPrivKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
 	var (
@@ -320,7 +319,7 @@ func TestMsgServer_RequestEmptyBatchTx(t *testing.T) {
 }
 
 func TestMsgServer_SubmitEthereumEvent(t *testing.T) {
-	ethPrivKey, err := ethCrypto.GenerateKey()
+	ethPrivKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
 	var (
@@ -373,7 +372,7 @@ func TestMsgServer_SubmitEthereumEvent(t *testing.T) {
 }
 
 func TestMsgServer_SetDelegateKeys(t *testing.T) {
-	ethPrivKey, err := ethCrypto.GenerateKey()
+	ethPrivKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
 	var (


### PR DESCRIPTION
Remove some unused functions, remove an unnecessary type assertion,
check unchecked errors in test, and remove duplicate imports.