### PR TITLE
E2E bugfixes around ERC20-originated denoms

### DIFF
--- a/integration_tests/setup_test.go
+++ b/integration_tests/setup_test.go
@@ -333,11 +333,7 @@ func (s *IntegrationTestSuite) initGenesis() {
 	s.Require().NoError(cdc.UnmarshalJSON(appGenState[gravitytypes.ModuleName], &gravityGenState))
 	gravityGenState.Params.GravityId = "gravitytest"
 	gravityGenState.Params.BridgeEthereumAddress = gravityContract.String()
-	gravityGenState.Erc20ToDenoms = append(gravityGenState.Erc20ToDenoms,
-		&gravitytypes.ERC20ToDenom{
-			Erc20: testERC20contract.Hex(),
-			Denom: "DDS",
-		})
+
 	bz, err = cdc.MarshalJSON(&gravityGenState)
 	s.Require().NoError(err)
 	appGenState[gravitytypes.ModuleName] = bz


### PR DESCRIPTION
The test you were setting up is meant to be an ERC20-originated denom test rather than the reverse. The chain also had no metadata for a cosmos "DDS" denom, only "testgb". Additionally, denoms should only be treated as cosmos-originated if they were deployed through the contract using the deploy ERC20 functionality.

This will still be broken, but will pass once the capitalization issue of contract strings is fixed on main.