### PR TITLE
Fix ERC20 address casing in denoms

### DIFF
--- a/module/x/gravity/abci_test.go
+++ b/module/x/gravity/abci_test.go
@@ -244,7 +244,7 @@ func TestBatchTxTimeout(t *testing.T) {
 		mySender, _         = sdk.AccAddressFromBech32("cosmos1ahx7f8wyertuus9r20284ej0asrs085case3kn")
 		myReceiver          = common.HexToAddress("0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7")
 		myTokenContractAddr = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5") // Pickle
-		allVouchers         = sdk.NewCoins(types.NewERC20Token(99999, myTokenContractAddr.Hex()).GravityCoin())
+		allVouchers         = sdk.NewCoins(types.NewERC20Token(99999, myTokenContractAddr).GravityCoin())
 	)
 
 	require.Greater(t, params.AverageBlockTime, uint64(0))

--- a/module/x/gravity/cosmos_originated_test.go
+++ b/module/x/gravity/cosmos_originated_test.go
@@ -102,7 +102,7 @@ func addDenomToERC20Relation(tv *testingVars) {
 	require.NoError(tv.t, err)
 	assert.True(tv.t, isCosmosOriginated)
 
-	isCosmosOriginated, gotDenom := tv.input.GravityKeeper.ERC20ToDenomLookup(tv.ctx, tv.erc20)
+	isCosmosOriginated, gotDenom := tv.input.GravityKeeper.ERC20ToDenomLookup(tv.ctx, common.HexToAddress(tv.erc20))
 	assert.True(tv.t, isCosmosOriginated)
 
 	assert.Equal(tv.t, tv.denom, gotDenom)

--- a/module/x/gravity/handler_test.go
+++ b/module/x/gravity/handler_test.go
@@ -2,6 +2,7 @@ package gravity_test
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"time"
 
@@ -86,7 +87,8 @@ func TestMsgSubmitEthreumEventSendToCosmosSingleValidator(t *testing.T) {
 		myValAddr                         = sdk.ValAddress(myOrchestratorAddr) // revisit when proper mapping is impl in keeper
 		myNonce                           = uint64(1)
 		anyETHAddr                        = "0xf9613b532673Cc223aBa451dFA8539B87e1F666D"
-		tokenETHAddr                      = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+		tokenETHAddr                      = common.HexToAddress("0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e").Hex()
+		denom                             = fmt.Sprintf("gravity%s", tokenETHAddr)
 		myBlockTime                       = time.Date(2020, 9, 14, 15, 20, 10, 0, time.UTC)
 		amountA, _                        = sdk.NewIntFromString("50000000000000000000")  // 50 ETH
 		amountB, _                        = sdk.NewIntFromString("100000000000000000000") // 100 ETH
@@ -128,7 +130,7 @@ func TestMsgSubmitEthreumEventSendToCosmosSingleValidator(t *testing.T) {
 	// and vouchers added to the account
 
 	balance := bk.GetAllBalances(ctx, myCosmosAddr)
-	require.Equal(t, sdk.Coins{sdk.NewCoin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", amountA)}, balance)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(denom, amountA)}, balance)
 
 	// Test to reject duplicate deposit
 	// when
@@ -138,7 +140,7 @@ func TestMsgSubmitEthreumEventSendToCosmosSingleValidator(t *testing.T) {
 	// then
 	require.Error(t, err)
 	balance = bk.GetAllBalances(ctx, myCosmosAddr)
-	require.Equal(t, sdk.Coins{sdk.NewCoin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", amountA)}, balance)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(denom, amountA)}, balance)
 
 	// Test to reject skipped nonce
 
@@ -163,7 +165,7 @@ func TestMsgSubmitEthreumEventSendToCosmosSingleValidator(t *testing.T) {
 	gravity.EndBlocker(ctx, gk)
 	// then
 	balance = bk.GetAllBalances(ctx, myCosmosAddr)
-	require.Equal(t, sdk.Coins{sdk.NewCoin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", amountA)}, balance)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(denom, amountA)}, balance)
 
 	// Test to finally accept consecutive nonce
 	sendToCosmosEvent = &types.SendToCosmosEvent{
@@ -186,7 +188,7 @@ func TestMsgSubmitEthreumEventSendToCosmosSingleValidator(t *testing.T) {
 	// then
 	require.NoError(t, err)
 	balance = bk.GetAllBalances(ctx, myCosmosAddr)
-	require.Equal(t, sdk.Coins{sdk.NewCoin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", amountB)}, balance)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(denom, amountB)}, balance)
 }
 
 func TestMsgSubmitEthreumEventSendToCosmosMultiValidator(t *testing.T) {
@@ -200,7 +202,8 @@ func TestMsgSubmitEthreumEventSendToCosmosMultiValidator(t *testing.T) {
 		valAddr3             = sdk.ValAddress(orchestratorAddr3) // revisit when proper mapping is impl in keeper
 		myNonce              = uint64(1)
 		anyETHAddr           = "0xf9613b532673Cc223aBa451dFA8539B87e1F666D"
-		tokenETHAddr         = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+		tokenETHAddr         = common.HexToAddress("0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e").Hex()
+		denom                = fmt.Sprintf("gravity%s", tokenETHAddr)
 		myBlockTime          = time.Date(2020, 9, 14, 15, 20, 10, 0, time.UTC)
 	)
 	input := keeper.CreateTestEnv(t)
@@ -257,7 +260,7 @@ func TestMsgSubmitEthreumEventSendToCosmosMultiValidator(t *testing.T) {
 	require.NotNil(t, a1)
 	// and vouchers not yet added to the account
 	balance1 := input.BankKeeper.GetAllBalances(ctx, myCosmosAddr)
-	require.NotEqual(t, sdk.Coins{sdk.NewInt64Coin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", 12)}, balance1)
+	require.NotEqual(t, sdk.Coins{sdk.NewInt64Coin(denom, 12)}, balance1)
 
 	// when
 	ctx = ctx.WithBlockTime(myBlockTime)
@@ -270,7 +273,7 @@ func TestMsgSubmitEthreumEventSendToCosmosMultiValidator(t *testing.T) {
 	require.NotNil(t, a2)
 	// and vouchers now added to the account
 	balance2 := input.BankKeeper.GetAllBalances(ctx, myCosmosAddr)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", 12)}, balance2)
+	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(denom, 12)}, balance2)
 
 	// when
 	ctx = ctx.WithBlockTime(myBlockTime)
@@ -283,7 +286,7 @@ func TestMsgSubmitEthreumEventSendToCosmosMultiValidator(t *testing.T) {
 	require.NotNil(t, a3)
 	// and no additional added to the account
 	balance3 := input.BankKeeper.GetAllBalances(ctx, myCosmosAddr)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", 12)}, balance3)
+	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(denom, 12)}, balance3)
 }
 
 func TestMsgSetDelegateAddresses(t *testing.T) {

--- a/module/x/gravity/handler_test.go
+++ b/module/x/gravity/handler_test.go
@@ -23,14 +23,14 @@ func TestHandleMsgSendToEthereum(t *testing.T) {
 		userCosmosAddr, _               = sdk.AccAddressFromBech32("cosmos1990z7dqsvh8gthw9pa5sn4wuy2xrsd80mg5z6y")
 		blockTime                       = time.Date(2020, 9, 14, 15, 20, 10, 0, time.UTC)
 		blockHeight           int64     = 200
-		denom                           = "gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+		denom                           = types.GravityDenom(common.HexToAddress("0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"))
 		startingCoinAmount, _           = sdk.NewIntFromString("150000000000000000000") // 150 ETH worth, required to reach above u64 limit (which is about 18 ETH)
 		sendAmount, _                   = sdk.NewIntFromString("50000000000000000000")  // 50 ETH
 		feeAmount, _                    = sdk.NewIntFromString("5000000000000000000")   // 5 ETH
 		startingCoins         sdk.Coins = sdk.Coins{sdk.NewCoin(denom, startingCoinAmount)}
 		sendingCoin           sdk.Coin  = sdk.NewCoin(denom, sendAmount)
 		feeCoin               sdk.Coin  = sdk.NewCoin(denom, feeAmount)
-		ethDestination                  = "0x3c9289da00b02dC623d0D8D907619890301D26d4"
+		ethDestination                  = common.HexToAddress("0x3c9289da00b02dC623d0D8D907619890301D26d4").Hex()
 	)
 
 	// we start by depositing some funds into the users balance to send
@@ -86,7 +86,7 @@ func TestMsgSubmitEthreumEventSendToCosmosSingleValidator(t *testing.T) {
 		myCosmosAddr, _                   = sdk.AccAddressFromBech32("cosmos16ahjkfqxpp6lvfy9fpfnfjg39xr96qett0alj5")
 		myValAddr                         = sdk.ValAddress(myOrchestratorAddr) // revisit when proper mapping is impl in keeper
 		myNonce                           = uint64(1)
-		anyETHAddr                        = "0xf9613b532673Cc223aBa451dFA8539B87e1F666D"
+		anyETHAddr                        = common.HexToAddress("0xf9613b532673Cc223aBa451dFA8539B87e1F666D").Hex()
 		tokenETHAddr                      = common.HexToAddress("0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e").Hex()
 		denom                             = fmt.Sprintf("gravity%s", tokenETHAddr)
 		myBlockTime                       = time.Date(2020, 9, 14, 15, 20, 10, 0, time.UTC)
@@ -201,7 +201,7 @@ func TestMsgSubmitEthreumEventSendToCosmosMultiValidator(t *testing.T) {
 		valAddr2             = sdk.ValAddress(orchestratorAddr2) // revisit when proper mapping is impl in keeper
 		valAddr3             = sdk.ValAddress(orchestratorAddr3) // revisit when proper mapping is impl in keeper
 		myNonce              = uint64(1)
-		anyETHAddr           = "0xf9613b532673Cc223aBa451dFA8539B87e1F666D"
+		anyETHAddr           = common.HexToAddress("0xf9613b532673Cc223aBa451dFA8539B87e1F666D").Hex()
 		tokenETHAddr         = common.HexToAddress("0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e").Hex()
 		denom                = fmt.Sprintf("gravity%s", tokenETHAddr)
 		myBlockTime          = time.Date(2020, 9, 14, 15, 20, 10, 0, time.UTC)

--- a/module/x/gravity/handler_test.go
+++ b/module/x/gravity/handler_test.go
@@ -2,7 +2,6 @@ package gravity_test
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 	"time"
 
@@ -86,9 +85,9 @@ func TestMsgSubmitEthreumEventSendToCosmosSingleValidator(t *testing.T) {
 		myCosmosAddr, _                   = sdk.AccAddressFromBech32("cosmos16ahjkfqxpp6lvfy9fpfnfjg39xr96qett0alj5")
 		myValAddr                         = sdk.ValAddress(myOrchestratorAddr) // revisit when proper mapping is impl in keeper
 		myNonce                           = uint64(1)
-		anyETHAddr                        = common.HexToAddress("0xf9613b532673Cc223aBa451dFA8539B87e1F666D").Hex()
-		tokenETHAddr                      = common.HexToAddress("0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e").Hex()
-		denom                             = fmt.Sprintf("gravity%s", tokenETHAddr)
+		anyETHAddr                        = common.HexToAddress("0xf9613b532673Cc223aBa451dFA8539B87e1F666D")
+		tokenETHAddr                      = common.HexToAddress("0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e")
+		denom                             = types.GravityDenom(tokenETHAddr)
 		myBlockTime                       = time.Date(2020, 9, 14, 15, 20, 10, 0, time.UTC)
 		amountA, _                        = sdk.NewIntFromString("50000000000000000000")  // 50 ETH
 		amountB, _                        = sdk.NewIntFromString("100000000000000000000") // 100 ETH
@@ -103,14 +102,14 @@ func TestMsgSubmitEthreumEventSendToCosmosSingleValidator(t *testing.T) {
 
 	myErc20 := types.ERC20Token{
 		Amount:   amountA,
-		Contract: tokenETHAddr,
+		Contract: tokenETHAddr.Hex(),
 	}
 
 	sendToCosmosEvent := &types.SendToCosmosEvent{
 		EventNonce:     myNonce,
 		TokenContract:  myErc20.Contract,
 		Amount:         myErc20.Amount,
-		EthereumSender: anyETHAddr,
+		EthereumSender: anyETHAddr.Hex(),
 		CosmosReceiver: myCosmosAddr.String(),
 	}
 
@@ -148,7 +147,7 @@ func TestMsgSubmitEthreumEventSendToCosmosSingleValidator(t *testing.T) {
 		EventNonce:     uint64(3),
 		TokenContract:  myErc20.Contract,
 		Amount:         myErc20.Amount,
-		EthereumSender: anyETHAddr,
+		EthereumSender: anyETHAddr.Hex(),
 		CosmosReceiver: myCosmosAddr.String(),
 	}
 
@@ -172,7 +171,7 @@ func TestMsgSubmitEthreumEventSendToCosmosSingleValidator(t *testing.T) {
 		EventNonce:     uint64(2),
 		TokenContract:  myErc20.Contract,
 		Amount:         myErc20.Amount,
-		EthereumSender: anyETHAddr,
+		EthereumSender: anyETHAddr.Hex(),
 		CosmosReceiver: myCosmosAddr.String(),
 	}
 
@@ -201,9 +200,9 @@ func TestMsgSubmitEthreumEventSendToCosmosMultiValidator(t *testing.T) {
 		valAddr2             = sdk.ValAddress(orchestratorAddr2) // revisit when proper mapping is impl in keeper
 		valAddr3             = sdk.ValAddress(orchestratorAddr3) // revisit when proper mapping is impl in keeper
 		myNonce              = uint64(1)
-		anyETHAddr           = common.HexToAddress("0xf9613b532673Cc223aBa451dFA8539B87e1F666D").Hex()
-		tokenETHAddr         = common.HexToAddress("0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e").Hex()
-		denom                = fmt.Sprintf("gravity%s", tokenETHAddr)
+		anyETHAddr           = common.HexToAddress("0xf9613b532673Cc223aBa451dFA8539B87e1F666D")
+		tokenETHAddr         = common.HexToAddress("0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e")
+		denom                = types.GravityDenom(tokenETHAddr)
 		myBlockTime          = time.Date(2020, 9, 14, 15, 20, 10, 0, time.UTC)
 	)
 	input := keeper.CreateTestEnv(t)
@@ -216,14 +215,14 @@ func TestMsgSubmitEthreumEventSendToCosmosMultiValidator(t *testing.T) {
 
 	myErc20 := types.ERC20Token{
 		Amount:   sdk.NewInt(12),
-		Contract: tokenETHAddr,
+		Contract: tokenETHAddr.Hex(),
 	}
 
 	ethClaim1 := &types.SendToCosmosEvent{
 		EventNonce:     myNonce,
 		TokenContract:  myErc20.Contract,
 		Amount:         myErc20.Amount,
-		EthereumSender: anyETHAddr,
+		EthereumSender: anyETHAddr.Hex(),
 		CosmosReceiver: myCosmosAddr.String(),
 	}
 	ethClaim1a, err := types.PackEvent(ethClaim1)
@@ -233,7 +232,7 @@ func TestMsgSubmitEthreumEventSendToCosmosMultiValidator(t *testing.T) {
 		EventNonce:     myNonce,
 		TokenContract:  myErc20.Contract,
 		Amount:         myErc20.Amount,
-		EthereumSender: anyETHAddr,
+		EthereumSender: anyETHAddr.Hex(),
 		CosmosReceiver: myCosmosAddr.String(),
 	}
 	ethClaim2a, err := types.PackEvent(ethClaim2)
@@ -243,7 +242,7 @@ func TestMsgSubmitEthreumEventSendToCosmosMultiValidator(t *testing.T) {
 		EventNonce:     myNonce,
 		TokenContract:  myErc20.Contract,
 		Amount:         myErc20.Amount,
-		EthereumSender: anyETHAddr,
+		EthereumSender: anyETHAddr.Hex(),
 		CosmosReceiver: myCosmosAddr.String(),
 	}
 	ethClaim3a, err := types.PackEvent(ethClaim3)

--- a/module/x/gravity/keeper/batch_test.go
+++ b/module/x/gravity/keeper/batch_test.go
@@ -21,7 +21,7 @@ func TestBatches(t *testing.T) {
 		myReceiver          = common.HexToAddress("0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7")
 		myTokenContractAddr = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5") // Pickle
 		allVouchers         = sdk.NewCoins(
-			types.NewERC20Token(99999, myTokenContractAddr.Hex()).GravityCoin(),
+			types.NewERC20Token(99999, myTokenContractAddr).GravityCoin(),
 		)
 	)
 
@@ -313,9 +313,9 @@ func TestPoolTxRefund(t *testing.T) {
 		myReceiver          = common.HexToAddress("0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7")
 		myTokenContractAddr = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5") // Pickle
 		allVouchers         = sdk.NewCoins(
-			types.NewERC20Token(414, myTokenContractAddr.Hex()).GravityCoin(),
+			types.NewERC20Token(414, myTokenContractAddr).GravityCoin(),
 		)
-		myDenom = types.NewERC20Token(1, myTokenContractAddr.Hex()).GravityCoin().Denom
+		myDenom = types.NewERC20Token(1, myTokenContractAddr).GravityCoin().Denom
 	)
 
 	// mint some voucher first
@@ -364,7 +364,7 @@ func TestEmptyBatch(t *testing.T) {
 		mySender, _         = sdk.AccAddressFromBech32("cosmos1ahx7f8wyertuus9r20284ej0asrs085case3kn")
 		myTokenContractAddr = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5") // Pickle
 		allVouchers         = sdk.NewCoins(
-			types.NewERC20Token(99999, myTokenContractAddr.Hex()).GravityCoin(),
+			types.NewERC20Token(99999, myTokenContractAddr).GravityCoin(),
 		)
 	)
 

--- a/module/x/gravity/keeper/cosmos_originated.go
+++ b/module/x/gravity/keeper/cosmos_originated.go
@@ -12,7 +12,7 @@ import (
 
 func (k Keeper) getCosmosOriginatedDenom(ctx sdk.Context, tokenContract common.Address) (string, bool) {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.MakeERC20ToDenomKey(tokenContract.Hex()))
+	bz := store.Get(types.MakeERC20ToDenomKey(tokenContract))
 
 	if bz != nil {
 		return string(bz), true
@@ -33,7 +33,7 @@ func (k Keeper) getCosmosOriginatedERC20(ctx sdk.Context, denom string) (common.
 func (k Keeper) setCosmosOriginatedDenomToERC20(ctx sdk.Context, denom string, tokenContract common.Address) {
 	store := ctx.KVStore(k.storeKey)
 	store.Set(types.MakeDenomToERC20Key(denom), tokenContract.Bytes())
-	store.Set(types.MakeERC20ToDenomKey(tokenContract.Hex()), []byte(denom))
+	store.Set(types.MakeERC20ToDenomKey(tokenContract), []byte(denom))
 }
 
 // DenomToERC20 returns (bool isCosmosOriginated, string ERC20, err)

--- a/module/x/gravity/keeper/cosmos_originated.go
+++ b/module/x/gravity/keeper/cosmos_originated.go
@@ -10,9 +10,9 @@ import (
 	"github.com/peggyjv/gravity-bridge/module/x/gravity/types"
 )
 
-func (k Keeper) getCosmosOriginatedDenom(ctx sdk.Context, tokenContract string) (string, bool) {
+func (k Keeper) getCosmosOriginatedDenom(ctx sdk.Context, tokenContract common.Address) (string, bool) {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.MakeERC20ToDenomKey(tokenContract))
+	bz := store.Get(types.MakeERC20ToDenomKey(tokenContract.Hex()))
 
 	if bz != nil {
 		return string(bz), true
@@ -30,10 +30,10 @@ func (k Keeper) getCosmosOriginatedERC20(ctx sdk.Context, denom string) (common.
 	return common.BytesToAddress([]byte{}), false
 }
 
-func (k Keeper) setCosmosOriginatedDenomToERC20(ctx sdk.Context, denom string, tokenContract string) {
+func (k Keeper) setCosmosOriginatedDenomToERC20(ctx sdk.Context, denom string, tokenContract common.Address) {
 	store := ctx.KVStore(k.storeKey)
-	store.Set(types.MakeDenomToERC20Key(denom), common.HexToAddress(tokenContract).Bytes())
-	store.Set(types.MakeERC20ToDenomKey(tokenContract), []byte(denom))
+	store.Set(types.MakeDenomToERC20Key(denom), tokenContract.Bytes())
+	store.Set(types.MakeERC20ToDenomKey(tokenContract.Hex()), []byte(denom))
 }
 
 // DenomToERC20 returns (bool isCosmosOriginated, string ERC20, err)
@@ -62,7 +62,7 @@ func (k Keeper) DenomToERC20Lookup(ctx sdk.Context, denom string) (bool, common.
 // ERC20ToDenom returns (bool isCosmosOriginated, string denom, err)
 // Using this information, you can see if an ERC20 address represents an asset is native to Cosmos or Ethereum,
 // and get its corresponding denom
-func (k Keeper) ERC20ToDenomLookup(ctx sdk.Context, tokenContract string) (bool, string) {
+func (k Keeper) ERC20ToDenomLookup(ctx sdk.Context, tokenContract common.Address) (bool, string) {
 	// First try looking up tokenContract in index
 	dn1, exists := k.getCosmosOriginatedDenom(ctx, tokenContract)
 	if exists {

--- a/module/x/gravity/keeper/cosmos_originated.go
+++ b/module/x/gravity/keeper/cosmos_originated.go
@@ -71,8 +71,7 @@ func (k Keeper) ERC20ToDenomLookup(ctx sdk.Context, tokenContract common.Address
 	}
 
 	// If it is not in there, it is not a cosmos originated token, turn the ERC20 into a gravity denom
-
-	return false, types.NewERC20Token(0, tokenContract).GravityCoin().Denom
+	return false, types.GravityDenom(tokenContract)
 }
 
 // iterateERC20ToDenom iterates over erc20 to denom relations

--- a/module/x/gravity/keeper/ethereum_event_handler.go
+++ b/module/x/gravity/keeper/ethereum_event_handler.go
@@ -26,7 +26,7 @@ func (k Keeper) Handle(ctx sdk.Context, eve types.EthereumEvent) (err error) {
 	switch event := eve.(type) {
 	case *types.SendToCosmosEvent:
 		// Check if coin is Cosmos-originated asset and get denom
-		isCosmosOriginated, denom := k.ERC20ToDenomLookup(ctx, event.TokenContract)
+		isCosmosOriginated, denom := k.ERC20ToDenomLookup(ctx, common.HexToAddress(event.TokenContract))
 		addr, _ := sdk.AccAddressFromBech32(event.CosmosReceiver)
 		coins := sdk.Coins{sdk.NewCoin(denom, event.Amount)}
 
@@ -58,7 +58,7 @@ func (k Keeper) Handle(ctx sdk.Context, eve types.EthereumEvent) (err error) {
 		}
 
 		// add to denom-erc20 mapping
-		k.setCosmosOriginatedDenomToERC20(ctx, event.CosmosDenom, event.TokenContract)
+		k.setCosmosOriginatedDenomToERC20(ctx, event.CosmosDenom, common.HexToAddress(event.TokenContract))
 		k.AfterERC20DeployedEvent(ctx, *event)
 		return nil
 

--- a/module/x/gravity/keeper/genesis.go
+++ b/module/x/gravity/keeper/genesis.go
@@ -68,7 +68,7 @@ func InitGenesis(ctx sdk.Context, k Keeper, data types.GenesisState) {
 
 	// populate state with cosmos originated denom-erc20 mapping
 	for _, item := range data.Erc20ToDenoms {
-		k.setCosmosOriginatedDenomToERC20(ctx, item.Denom, item.Erc20)
+		k.setCosmosOriginatedDenomToERC20(ctx, item.Denom, common.HexToAddress(item.Erc20))
 	}
 
 	// reset outgoing txs in state

--- a/module/x/gravity/keeper/grpc_query.go
+++ b/module/x/gravity/keeper/grpc_query.go
@@ -299,7 +299,7 @@ func (k Keeper) BatchTxFees(c context.Context, req *types.BatchTxFeesRequest) (*
 
 func (k Keeper) ERC20ToDenom(c context.Context, req *types.ERC20ToDenomRequest) (*types.ERC20ToDenomResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
-	cosmosOriginated, denom := k.ERC20ToDenomLookup(ctx, req.Erc20)
+	cosmosOriginated, denom := k.ERC20ToDenomLookup(ctx, common.HexToAddress(req.Erc20))
 	res := &types.ERC20ToDenomResponse{
 		Denom:            denom,
 		CosmosOriginated: cosmosOriginated,

--- a/module/x/gravity/keeper/grpc_query.go
+++ b/module/x/gravity/keeper/grpc_query.go
@@ -289,7 +289,8 @@ func (k Keeper) BatchTxFees(c context.Context, req *types.BatchTxFeesRequest) (*
 	k.IterateOutgoingTxsByType(ctx, types.BatchTxPrefixByte, func(key []byte, otx types.OutgoingTx) bool {
 		btx, _ := otx.(*types.BatchTx)
 		for _, tx := range btx.Transactions {
-			res.Fees = append(res.Fees, tx.Erc20Fee.GravityCoin())
+			_, denom := k.ERC20ToDenomLookup(ctx, common.HexToAddress(tx.Erc20Fee.Contract))
+			res.Fees = append(res.Fees, sdk.NewCoin(denom, tx.Erc20Fee.Amount))
 		}
 		return false
 	})

--- a/module/x/gravity/keeper/keeper_test.go
+++ b/module/x/gravity/keeper/keeper_test.go
@@ -559,7 +559,7 @@ func TestKeeper_Migration(t *testing.T) {
 		myReceiver          = common.HexToAddress("0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7")
 		myTokenContractAddr = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5") // Pickle
 		allVouchers         = sdk.NewCoins(
-			types.NewERC20Token(99999, myTokenContractAddr.Hex()).GravityCoin(),
+			types.NewERC20Token(99999, myTokenContractAddr).GravityCoin(),
 		)
 	)
 

--- a/module/x/gravity/keeper/msg_server.go
+++ b/module/x/gravity/keeper/msg_server.go
@@ -213,6 +213,10 @@ func (k msgServer) SendToEthereum(c context.Context, msg *types.MsgSendToEthereu
 		return nil, err
 	}
 
+	// ensure the denoms provided in the message will map correctly if they are gravity denoms
+	types.NormalizeCoinDenom(&msg.Amount)
+	types.NormalizeCoinDenom(&msg.BridgeFee)
+
 	txID, err := k.createSendToEthereum(ctx, sender, msg.EthereumRecipient, msg.Amount, msg.BridgeFee)
 	if err != nil {
 		return nil, err
@@ -243,8 +247,8 @@ func (k msgServer) RequestBatchTx(c context.Context, msg *types.MsgRequestBatchT
 	ctx := sdk.UnwrapSDKContext(c)
 
 	// Check if the denom is a gravity coin, if not, check if there is a deployed ERC20 representing it.
-	// If not, error out
-	_, tokenContract, err := k.DenomToERC20Lookup(ctx, msg.Denom)
+	// If not, error out. Normalizes the format of the input denom if it's a gravity denom.
+	_, tokenContract, err := k.DenomToERC20Lookup(ctx, types.NormalizeDenom(msg.Denom))
 	if err != nil {
 		return nil, err
 	}

--- a/module/x/gravity/keeper/msg_server_test.go
+++ b/module/x/gravity/keeper/msg_server_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	ethCrypto "github.com/ethereum/go-ethereum/crypto"
@@ -93,7 +94,8 @@ func TestMsgServer_SendToEthereum(t *testing.T) {
 		orcAddr3, _ = sdk.AccAddressFromBech32("cosmos193fw83ynn76328pty4yl7473vg9x86alq2cft7")
 		valAddr3    = sdk.ValAddress(orcAddr3)
 
-		testDenom = "stake"
+		testDenom    = "stake"
+		testContract = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5")
 
 		balance = sdk.Coin{
 			Denom:  testDenom,
@@ -120,7 +122,7 @@ func TestMsgServer_SendToEthereum(t *testing.T) {
 	}
 
 	// create denom in keeper
-	gk.setCosmosOriginatedDenomToERC20(ctx, testDenom, "testcontractstring")
+	gk.setCosmosOriginatedDenomToERC20(ctx, testDenom, testContract)
 
 	// setup for GetValidatorEthereumAddress
 	gk.setValidatorEthereumAddress(ctx, valAddr1, ethAddr1)
@@ -157,7 +159,8 @@ func TestMsgServer_CancelSendToEthereum(t *testing.T) {
 		orcAddr3, _ = sdk.AccAddressFromBech32("cosmos193fw83ynn76328pty4yl7473vg9x86alq2cft7")
 		valAddr3    = sdk.ValAddress(orcAddr3)
 
-		testDenom = "stake"
+		testDenom    = "stake"
+		testContract = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5")
 
 		balance = sdk.Coin{
 			Denom:  testDenom,
@@ -184,7 +187,7 @@ func TestMsgServer_CancelSendToEthereum(t *testing.T) {
 	}
 
 	// create denom in keeper
-	gk.setCosmosOriginatedDenomToERC20(ctx, testDenom, "testcontractstring")
+	gk.setCosmosOriginatedDenomToERC20(ctx, testDenom, testContract)
 
 	// setup for GetValidatorEthereumAddress
 	gk.setValidatorEthereumAddress(ctx, valAddr1, ethAddr1)
@@ -205,6 +208,7 @@ func TestMsgServer_CancelSendToEthereum(t *testing.T) {
 		Id:     response.Id,
 		Sender: orcAddr1.String(),
 	}
+
 	_, err = msgServer.CancelSendToEthereum(sdk.WrapSDKContext(ctx), cancelMsg)
 	require.NoError(t, err)
 }
@@ -228,7 +232,8 @@ func TestMsgServer_RequestBatchTx(t *testing.T) {
 		orcAddr3, _ = sdk.AccAddressFromBech32("cosmos193fw83ynn76328pty4yl7473vg9x86alq2cft7")
 		valAddr3    = sdk.ValAddress(orcAddr3)
 
-		testDenom = "stake"
+		testDenom    = "stake"
+		testContract = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5")
 
 		balance = sdk.Coin{
 			Denom:  testDenom,
@@ -255,7 +260,7 @@ func TestMsgServer_RequestBatchTx(t *testing.T) {
 	}
 
 	// create denom in keeper
-	gk.setCosmosOriginatedDenomToERC20(ctx, testDenom, "testcontractstring")
+	gk.setCosmosOriginatedDenomToERC20(ctx, testDenom, testContract)
 
 	// setup for GetValidatorEthereumAddress
 	gk.setValidatorEthereumAddress(ctx, valAddr1, ethAddr1)
@@ -296,7 +301,8 @@ func TestMsgServer_RequestEmptyBatchTx(t *testing.T) {
 		orcAddr3, _ = sdk.AccAddressFromBech32("cosmos193fw83ynn76328pty4yl7473vg9x86alq2cft7")
 		valAddr3    = sdk.ValAddress(orcAddr3)
 
-		testDenom = "stake"
+		testDenom    = "stake"
+		testContract = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5")
 	)
 
 	{ // setup for getSignerValidator
@@ -305,7 +311,7 @@ func TestMsgServer_RequestEmptyBatchTx(t *testing.T) {
 	}
 
 	// create denom in keeper
-	gk.setCosmosOriginatedDenomToERC20(ctx, testDenom, "testcontractstring")
+	gk.setCosmosOriginatedDenomToERC20(ctx, testDenom, testContract)
 
 	msgServer := NewMsgServerImpl(gk)
 
@@ -337,6 +343,8 @@ func TestMsgServer_SubmitEthereumEvent(t *testing.T) {
 
 		orcAddr3, _ = sdk.AccAddressFromBech32("cosmos193fw83ynn76328pty4yl7473vg9x86alq2cft7")
 		valAddr3    = sdk.ValAddress(orcAddr3)
+
+		testContract = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5")
 	)
 
 	{ // setup for getSignerValidator
@@ -351,7 +359,7 @@ func TestMsgServer_SubmitEthereumEvent(t *testing.T) {
 
 	sendToCosmosEvent := &types.SendToCosmosEvent{
 		EventNonce:     1,
-		TokenContract:  "test-token-contract-string",
+		TokenContract:  testContract.Hex(),
 		Amount:         sdk.NewInt(1000),
 		EthereumSender: ethAddr1.String(),
 		CosmosReceiver: orcAddr1.String(),

--- a/module/x/gravity/keeper/pool.go
+++ b/module/x/gravity/keeper/pool.go
@@ -82,19 +82,18 @@ func (k Keeper) cancelSendToEthereum(ctx sdk.Context, id uint64, s string) error
 		return fmt.Errorf("can't cancel a message you didn't send")
 	}
 
-	totalToRefund := send.Erc20Token.GravityCoin()
-	totalToRefund.Amount = totalToRefund.Amount.Add(send.Erc20Fee.Amount)
-	totalToRefundCoins := sdk.NewCoins(totalToRefund)
-	isCosmosOriginated, _ := k.ERC20ToDenomLookup(ctx, send.Erc20Token.Contract)
+	isCosmosOriginated, denom := k.ERC20ToDenomLookup(ctx, common.HexToAddress(send.Erc20Token.Contract))
+	amountToRefund := send.Erc20Token.Amount.Add(send.Erc20Fee.Amount)
+	coinsToRefund := sdk.NewCoins(sdk.NewCoin(denom, amountToRefund))
 
 	// If it is not cosmos-originated the coins are minted
 	if !isCosmosOriginated {
-		if err := k.bankKeeper.MintCoins(ctx, types.ModuleName, totalToRefundCoins); err != nil {
-			return sdkerrors.Wrapf(err, "mint vouchers coins: %s", totalToRefundCoins)
+		if err := k.bankKeeper.MintCoins(ctx, types.ModuleName, coinsToRefund); err != nil {
+			return sdkerrors.Wrapf(err, "mint vouchers coins: %s", coinsToRefund)
 		}
 	}
 
-	if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, sender, totalToRefundCoins); err != nil {
+	if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, sender, coinsToRefund); err != nil {
 		return sdkerrors.Wrap(err, "sending coins from module account")
 	}
 

--- a/module/x/gravity/keeper/pool_test.go
+++ b/module/x/gravity/keeper/pool_test.go
@@ -19,7 +19,7 @@ func TestAddToOutgoingPool(t *testing.T) {
 		myTokenContractAddr = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5")
 	)
 	// mint some voucher first
-	allVouchers := sdk.Coins{types.NewERC20Token(99999, myTokenContractAddr.Hex()).GravityCoin()}
+	allVouchers := sdk.Coins{types.NewERC20Token(99999, myTokenContractAddr).GravityCoin()}
 	err := input.BankKeeper.MintCoins(ctx, types.ModuleName, allVouchers)
 	require.NoError(t, err)
 

--- a/module/x/gravity/keeper/test_common.go
+++ b/module/x/gravity/keeper/test_common.go
@@ -201,16 +201,17 @@ var (
 
 // TestInput stores the various keepers required to test gravity
 type TestInput struct {
-	GravityKeeper  Keeper
-	AccountKeeper  authkeeper.AccountKeeper
-	StakingKeeper  stakingkeeper.Keeper
-	SlashingKeeper slashingkeeper.Keeper
-	DistKeeper     distrkeeper.Keeper
-	BankKeeper     bankkeeper.BaseKeeper
-	GovKeeper      govkeeper.Keeper
-	Context        sdk.Context
-	Marshaler      codec.Codec
-	LegacyAmino    *codec.LegacyAmino
+	GravityKeeper   Keeper
+	AccountKeeper   authkeeper.AccountKeeper
+	StakingKeeper   stakingkeeper.Keeper
+	SlashingKeeper  slashingkeeper.Keeper
+	DistKeeper      distrkeeper.Keeper
+	BankKeeper      bankkeeper.BaseKeeper
+	GovKeeper       govkeeper.Keeper
+	Context         sdk.Context
+	Marshaler       codec.Codec
+	LegacyAmino     *codec.LegacyAmino
+	GravityStoreKey *sdk.KVStoreKey
 }
 
 func (input TestInput) AddSendToEthTxsToPool(t *testing.T, ctx sdk.Context, tokenContract gethcommon.Address, sender sdk.AccAddress, receiver gethcommon.Address, ids ...uint64) {
@@ -434,16 +435,17 @@ func CreateTestEnv(t *testing.T) TestInput {
 	k.setParams(ctx, TestingGravityParams)
 
 	return TestInput{
-		GravityKeeper:  k,
-		AccountKeeper:  accountKeeper,
-		BankKeeper:     bankKeeper,
-		StakingKeeper:  stakingKeeper,
-		SlashingKeeper: slashingKeeper,
-		DistKeeper:     distKeeper,
-		GovKeeper:      govKeeper,
-		Context:        ctx,
-		Marshaler:      marshaler,
-		LegacyAmino:    cdc,
+		GravityKeeper:   k,
+		AccountKeeper:   accountKeeper,
+		BankKeeper:      bankKeeper,
+		StakingKeeper:   stakingKeeper,
+		SlashingKeeper:  slashingKeeper,
+		DistKeeper:      distKeeper,
+		GovKeeper:       govKeeper,
+		Context:         ctx,
+		Marshaler:       marshaler,
+		LegacyAmino:     cdc,
+		GravityStoreKey: gravityKey,
 	}
 }
 

--- a/module/x/gravity/keeper/test_common.go
+++ b/module/x/gravity/keeper/test_common.go
@@ -215,8 +215,8 @@ type TestInput struct {
 
 func (input TestInput) AddSendToEthTxsToPool(t *testing.T, ctx sdk.Context, tokenContract gethcommon.Address, sender sdk.AccAddress, receiver gethcommon.Address, ids ...uint64) {
 	for i, id := range ids {
-		amount := types.NewERC20Token(uint64(i+100), tokenContract.Hex()).GravityCoin()
-		fee := types.NewERC20Token(id, tokenContract.Hex()).GravityCoin()
+		amount := types.NewERC20Token(uint64(i+100), tokenContract).GravityCoin()
+		fee := types.NewERC20Token(id, tokenContract).GravityCoin()
 		_, err := input.GravityKeeper.createSendToEthereum(ctx, sender, receiver.Hex(), amount, fee)
 		require.NoError(t, err)
 	}

--- a/module/x/gravity/migrations/v1/key.go
+++ b/module/x/gravity/migrations/v1/key.go
@@ -48,6 +48,10 @@ const (
 	LastObservedSignerSetKey
 )
 
+func MakeOldERC20ToDenomKey(erc20 string) []byte {
+	return append([]byte{ERC20ToDenomKey}, []byte(erc20)...)
+}
+
 func MakeNewERC20ToDenomKey(erc20 common.Address) []byte {
 	return append([]byte{ERC20ToDenomKey}, erc20.Bytes()...)
 }

--- a/module/x/gravity/migrations/v1/key.go
+++ b/module/x/gravity/migrations/v1/key.go
@@ -1,0 +1,53 @@
+package v1
+
+import "github.com/ethereum/go-ethereum/common"
+
+const (
+	// StoreKey to be used when creating the KVStore
+	StoreKey = "gravity"
+)
+
+// just replicating the current keyset in full rather than trying to hand count and
+// manually assign the iota values
+const (
+	_ = byte(iota)
+	// Key Delegation
+	ValidatorEthereumAddressKey
+	OrchestratorValidatorAddressKey
+	EthereumOrchestratorAddressKey
+
+	// Core types
+	EthereumSignatureKey
+	EthereumEventVoteRecordKey
+	OutgoingTxKey
+	SendToEthereumKey
+
+	// Latest nonce indexes
+	LastEventNonceByValidatorKey
+	LastObservedEventNonceKey
+	LatestSignerSetTxNonceKey
+	LastSlashedOutgoingTxBlockKey
+	LastSlashedSignerSetTxNonceKey
+	LastOutgoingBatchNonceKey
+
+	// LastSendToEthereumIDKey indexes the lastTxPoolID
+	LastSendToEthereumIDKey
+
+	// LastEthereumBlockHeightKey indexes the latest Ethereum block height
+	LastEthereumBlockHeightKey
+
+	// DenomToERC20Key prefixes the index of Cosmos originated asset denoms to ERC20s
+	DenomToERC20Key
+
+	// ERC20ToDenomKey prefixes the index of Cosmos originated assets ERC20s to denoms
+	ERC20ToDenomKey
+
+	// LastUnBondingBlockHeightKey indexes the last validator unbonding block height
+	LastUnBondingBlockHeightKey
+
+	LastObservedSignerSetKey
+)
+
+func MakeNewERC20ToDenomKey(erc20 common.Address) []byte {
+	return append([]byte{ERC20ToDenomKey}, erc20.Bytes()...)
+}

--- a/module/x/gravity/migrations/v1/store.go
+++ b/module/x/gravity/migrations/v1/store.go
@@ -1,8 +1,6 @@
 package v1
 
 import (
-	"bytes"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -29,11 +27,10 @@ func migrateCosmosOriginatedERC20ToDenom(store storetypes.KVStore) error {
 
 	for ; iter.Valid(); iter.Next() {
 		oldKey := iter.Key()
-		contractString := string(bytes.TrimPrefix(oldKey, []byte{ERC20ToDenomKey}))
-		newKey := MakeNewERC20ToDenomKey(common.HexToAddress(contractString))
+		newKey := common.HexToAddress(string(oldKey)).Bytes()
 
 		prefixStore.Delete(oldKey)
-		prefixStore.Set([]byte(newKey), iter.Value())
+		prefixStore.Set(newKey, iter.Value())
 	}
 
 	return nil

--- a/module/x/gravity/migrations/v1/store.go
+++ b/module/x/gravity/migrations/v1/store.go
@@ -1,0 +1,40 @@
+package v1
+
+import (
+	"bytes"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func MigrateStore(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec) error {
+	ctx.Logger().Info("Gravity v1 to v2: Beginning store migration")
+
+	store := ctx.KVStore(storeKey)
+
+	migrateCosmosOriginatedERC20ToDenom(store)
+
+	ctx.Logger().Info("Gravty v1 to v2: Store migration complete")
+
+	return nil
+}
+
+func migrateCosmosOriginatedERC20ToDenom(store storetypes.KVStore) error {
+	prefixStore := prefix.NewStore(store, []byte{ERC20ToDenomKey})
+	iter := prefixStore.Iterator(nil, nil)
+	defer iter.Close()
+
+	for ; iter.Valid(); iter.Next() {
+		oldKey := iter.Key()
+		contractString := string(bytes.TrimPrefix(oldKey, []byte{ERC20ToDenomKey}))
+		newKey := MakeNewERC20ToDenomKey(common.HexToAddress(contractString))
+
+		prefixStore.Delete(oldKey)
+		prefixStore.Set([]byte(newKey), iter.Value())
+	}
+
+	return nil
+}

--- a/module/x/gravity/migrations/v1/store_test.go
+++ b/module/x/gravity/migrations/v1/store_test.go
@@ -1,0 +1,27 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/peggyjv/gravity-bridge/module/x/gravity/keeper"
+	"github.com/stretchr/testify/assert"
+)
+
+const denom string = "cosmos"
+const tokenContractString string = "0x2a24af0501a534fca004ee1bd667b783f205a546"
+
+func TestMigrateCosmosOriginatedERC20ToDenom(t *testing.T) {
+	input := keeper.CreateTestEnv(t)
+	ctx := input.Context
+	storeKey := input.GravityStoreKey
+
+	ctx.KVStore(storeKey).Set(MakeOldERC20ToDenomKey(tokenContractString), []byte(denom))
+
+	err := MigrateStore(ctx, storeKey, input.Marshaler)
+	assert.NoError(t, err)
+
+	tokenContract := common.HexToAddress(tokenContractString)
+	storedDenom := ctx.KVStore(storeKey).Get(MakeNewERC20ToDenomKey(tokenContract))
+	assert.Equal(t, denom, string(storedDenom))
+}

--- a/module/x/gravity/module.go
+++ b/module/x/gravity/module.go
@@ -105,7 +105,7 @@ func (AppModule) Name() string {
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
 func (AppModule) ConsensusVersion() uint64 {
-	return 1
+	return 2
 }
 
 // RegisterInvariants implements app module

--- a/module/x/gravity/types/ethereum.go
+++ b/module/x/gravity/types/ethereum.go
@@ -47,10 +47,10 @@ func EthereumAddrLessThan(e, o string) bool {
 /////////////////////////
 
 // NewERC20Token returns a new instance of an ERC20
-func NewERC20Token(amount uint64, contract string) ERC20Token {
+func NewERC20Token(amount uint64, contract common.Address) ERC20Token {
 	return ERC20Token{
 		Amount:   sdk.NewIntFromUint64(amount),
-		Contract: common.HexToAddress(contract).Hex(),
+		Contract: contract.Hex(),
 	}
 }
 
@@ -61,9 +61,13 @@ func NewSDKIntERC20Token(amount sdk.Int, contract common.Address) ERC20Token {
 	}
 }
 
+func GravityDenom(contract common.Address) string {
+	return strings.Join([]string{GravityDenomPrefix, contract.Hex()}, GravityDenomSeparator)
+}
+
 // GravityCoin returns the gravity representation of the ERC20
 func (e ERC20Token) GravityCoin() sdk.Coin {
-	return sdk.Coin{Amount: e.Amount, Denom: strings.Join([]string{GravityDenomPrefix, e.Contract}, GravityDenomSeparator)}
+	return sdk.Coin{Amount: e.Amount, Denom: GravityDenom(common.HexToAddress(e.Contract))}
 }
 
 func GravityDenomToERC20(denom string) (string, error) {
@@ -78,17 +82,29 @@ func GravityDenomToERC20(denom string) (string, error) {
 	case len(denom) != GravityDenomLen:
 		return "", fmt.Errorf("len(denom)(%d) not equal to GravityDenomLen(%d)", len(denom), GravityDenomLen)
 	default:
-		return contract, nil
+		return common.HexToAddress(contract).Hex(), nil
 	}
+}
+
+func NormalizeCoinDenom(coin *sdk.Coin) {
+	coin.Denom = NormalizeDenom(coin.Denom)
+}
+
+func NormalizeDenom(denom string) string {
+	if contract, err := GravityDenomToERC20(denom); err == nil {
+		return GravityDenom(common.HexToAddress(contract))
+	}
+
+	return denom
 }
 
 func NewSendToEthereumTx(id uint64, tokenContract common.Address, sender sdk.AccAddress, recipient common.Address, amount, feeAmount uint64) *SendToEthereum {
 	return &SendToEthereum{
 		Id:                id,
-		Erc20Fee:          NewERC20Token(feeAmount, tokenContract.Hex()),
+		Erc20Fee:          NewERC20Token(feeAmount, tokenContract),
 		Sender:            sender.String(),
 		EthereumRecipient: recipient.Hex(),
-		Erc20Token:        NewERC20Token(amount, tokenContract.Hex()),
+		Erc20Token:        NewERC20Token(amount, tokenContract),
 	}
 }
 

--- a/module/x/gravity/types/ethereum.go
+++ b/module/x/gravity/types/ethereum.go
@@ -50,7 +50,7 @@ func EthereumAddrLessThan(e, o string) bool {
 func NewERC20Token(amount uint64, contract string) ERC20Token {
 	return ERC20Token{
 		Amount:   sdk.NewIntFromUint64(amount),
-		Contract: contract,
+		Contract: common.HexToAddress(contract).Hex(),
 	}
 }
 

--- a/module/x/gravity/types/key.go
+++ b/module/x/gravity/types/key.go
@@ -141,8 +141,8 @@ func MakeDenomToERC20Key(denom string) []byte {
 	return append([]byte{DenomToERC20Key}, []byte(denom)...)
 }
 
-func MakeERC20ToDenomKey(erc20 string) []byte {
-	return append([]byte{ERC20ToDenomKey}, []byte(erc20)...)
+func MakeERC20ToDenomKey(erc20 common.Address) []byte {
+	return append([]byte{ERC20ToDenomKey}, erc20.Bytes()...)
 }
 
 func MakeSignerSetTxKey(nonce uint64) []byte {


### PR DESCRIPTION
It was discovered that inconsistent casing of ERC20 contract addresses was causing denomination mismatches when trying to send coins over the bridge. This PR does the following:

* Where possible, have functions take in `common.Address` types rather than strings
* When input is received either through the message server or in the Ethereum event handler, normalize references to denoms before using them to look up data in the keeper (e.g. messages sent with manually specified denoms in `sdk.Coin` or string literals)
* Change the keeper storage of the cosmos-originated ERC20-to-denom mapping to key off of `common.Address` bytes rather than string bytes (the opposite denom-to-ERC20 mapping was already doing this correctly, but by its nature creating a mismatch)
* Fix a bug in `cancelSendToEthereum` where it used the gravity denom format regardless of whether it was a cosmos-originated denom or not
* Fix a bug in the `BatchTxFees` query function where it assumed that every fee would be in gravity denom format, rather than checking to see if the contract mapped to a cosmos-originated denom
* Bump the consensus version to 2 and migrate the old ERC20-to-denom mapping in the keeper to the new one

It does not attempt to normalize every Ethereum address string stored by the keeper, as this does not seem to be causing issues in cases other than denom handling (mostly those address values are passed along to the Gravity contract by the relayer, and I am not aware of any issues with Ethereum delegate addresses). Please do let me know if you think we should try to migrate every instance of an Ethereum address string to the same normalized format.

To the best of my knowledge, if incorrect denoms have already minted coins, I think it's outside the scope of what the gravity module migration can do, and an update plan by someone updating this module would need to account for fixing up the values in the bank module. This should only have occurred in cases of Ethereum-originated denoms.