### PR TITLE
Skip failing or invalid logic calls

### DIFF
--- a/orchestrator/ethereum_gravity/src/logic_call.rs
+++ b/orchestrator/ethereum_gravity/src/logic_call.rs
@@ -299,6 +299,12 @@ fn test_logic_call_skips() {
     assert_eq!(skips.should_skip(&logic_call_1_nonce_2), true);
     assert_eq!(skips.should_skip(&logic_call_2), true);
 
+    skips.clear_old_calls(6000);
+
+    assert_eq!(skips.should_skip(&logic_call_1_nonce_1), true);
+    assert_eq!(skips.should_skip(&logic_call_1_nonce_2), true);
+    assert_eq!(skips.should_skip(&logic_call_2), true);
+
     skips.clear_old_calls(8850);
 
     assert_eq!(skips.should_skip(&logic_call_1_nonce_1), false);

--- a/orchestrator/ethereum_gravity/src/logic_call.rs
+++ b/orchestrator/ethereum_gravity/src/logic_call.rs
@@ -225,3 +225,55 @@ impl LogicCallSkips {
         }
     }
 }
+
+#[test]
+fn test_logic_call_skips() {
+    let logic_call_1_nonce_1 = LogicCall {
+        transfers: Vec::new(),
+        fees: Vec::new(),
+        logic_contract_address: EthAddress::default(),
+        payload: Vec::new(),
+        timeout: 1000,
+        invalidation_id: vec![0, 1, 2],
+        invalidation_nonce: 1,
+    };
+
+    let logic_call_1_nonce_2 = LogicCall {
+        transfers: Vec::new(),
+        fees: Vec::new(),
+        logic_contract_address: EthAddress::default(),
+        payload: Vec::new(),
+        timeout: 1000,
+        invalidation_id: vec![0, 1, 2],
+        invalidation_nonce: 2,
+    };
+
+    let logic_call_2 = LogicCall {
+        transfers: Vec::new(),
+        fees: Vec::new(),
+        logic_contract_address: EthAddress::default(),
+        payload: Vec::new(),
+        timeout: 1000,
+        invalidation_id: vec![3, 4, 5],
+        invalidation_nonce: 1,
+    };
+
+    let mut skips = LogicCallSkips::new();
+
+    assert_eq!(skips.should_skip(&logic_call_1_nonce_1), false);
+    assert_eq!(skips.should_skip(&logic_call_1_nonce_2), false);
+    assert_eq!(skips.should_skip(&logic_call_2), false);
+
+    skips.skip(&logic_call_1_nonce_1);
+    skips.skip(&logic_call_2);
+
+    assert_eq!(skips.should_skip(&logic_call_1_nonce_1), true);
+    assert_eq!(skips.should_skip(&logic_call_1_nonce_2), false);
+    assert_eq!(skips.should_skip(&logic_call_2), true);
+
+    skips.skip(&logic_call_1_nonce_2);
+
+    assert_eq!(skips.should_skip(&logic_call_1_nonce_1), true);
+    assert_eq!(skips.should_skip(&logic_call_1_nonce_2), true);
+    assert_eq!(skips.should_skip(&logic_call_2), true);
+}

--- a/orchestrator/relayer/src/logic_call_relaying.rs
+++ b/orchestrator/relayer/src/logic_call_relaying.rs
@@ -37,6 +37,10 @@ pub async fn relay_logic_calls(
     let mut oldest_signed_call: Option<LogicCall> = None;
     let mut oldest_signatures: Option<Vec<LogicCallConfirmResponse>> = None;
     for call in latest_calls {
+        if logic_call_skips.should_skip(&call) {
+            continue;
+        }
+
         let sigs = get_logic_call_signatures(
             grpc_client,
             call.invalidation_id.clone(),
@@ -48,10 +52,6 @@ pub async fn relay_logic_calls(
             let hash = encode_logic_call_confirm_hashed(gravity_id.clone(), call.clone());
             // this checks that the signatures for the logic call are actually possible to submit to the chain
             if current_valset.order_sigs(&hash, &sigs).is_ok() {
-                if logic_call_skips.should_skip(&call) {
-                    continue;
-                }
-
                 oldest_signed_call = Some(call);
                 oldest_signatures = Some(sigs);
             } else {

--- a/orchestrator/relayer/src/main_loop.rs
+++ b/orchestrator/relayer/src/main_loop.rs
@@ -1,11 +1,11 @@
 use crate::{
     batch_relaying::relay_batches, find_latest_valset::find_latest_valset,
-    logic_call_relaying::relay_logic_calls, valset_relaying::relay_valsets,
+    logic_call_relaying::{relay_logic_calls}, valset_relaying::relay_valsets,
 };
-use ethereum_gravity::{types::EthClient, utils::get_gravity_id};
+use ethereum_gravity::{types::EthClient, utils::get_gravity_id, logic_call::LogicCallSkips};
 use ethers::types::Address as EthAddress;
 use gravity_proto::gravity::query_client::QueryClient as GravityQueryClient;
-use std::time::Duration;
+use std::{time::Duration};
 use tonic::transport::Channel;
 
 pub const LOOP_SPEED: Duration = Duration::from_secs(17);
@@ -26,6 +26,8 @@ pub async fn relayer_main_loop(
         return;
     }
     let gravity_id = gravity_id.unwrap();
+    let mut logic_call_skips = LogicCallSkips::new();
+
     loop {
         let (async_resp, _) = tokio::join!(
             async {
@@ -70,6 +72,7 @@ pub async fn relayer_main_loop(
                     gravity_id.clone(),
                     LOOP_SPEED,
                     eth_gas_price_multiplier,
+                    &mut logic_call_skips,
                 )
                 .await;
             },


### PR DESCRIPTION
If we encounter a logic call that either returns an error when we relay it, or logically should not be relayed, we add it to a skip list to avoid attempting to process it in the future. When these calls would have been timed out based on the current Ethereum height plus a generous buffer to account for potential bridge inactivity, they are cleared from the skip list to prevent it from growing unbounded. Restarting the process will also clear the list, but should only risk repeating a failed transaction once per restart.