### PR TITLE
Remove deep_space patch

### DIFF
--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -50,6 +50,3 @@ ethermint = [
     "gorc/ethermint",
     "register_delegate_keys/ethermint",
 ]
-
-[patch.crates-io]
-deep_space = { git = "https://github.com/iqlusioninc/deep_space/", branch = "master" }

--- a/orchestrator/cosmos_gravity/Cargo.toml
+++ b/orchestrator/cosmos_gravity/Cargo.toml
@@ -11,7 +11,7 @@ gravity_utils = {path = "../gravity_utils"}
 ethereum_gravity = {path = "../ethereum_gravity"}
 gravity_proto = {path = "../gravity_proto/"}
 
-deep_space = "2.4.7"
+deep_space = { git = "https://github.com/iqlusioninc/deep_space/", branch = "master" }
 ethers = { git = "https://github.com/iqlusioninc/ethers-rs.git", branch="zaki/error_abi_support", features = ["abigen"] }
 clarity = "0.4.11"
 serde = "1.0"

--- a/orchestrator/ethereum_gravity/Cargo.toml
+++ b/orchestrator/ethereum_gravity/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 gravity_abi = { path = "../gravity_abi" }
 gravity_utils = { path = "../gravity_utils" }
 
-deep_space = "2.4.7"
+deep_space = { git = "https://github.com/iqlusioninc/deep_space/", branch = "master" }
 ethers = { git = "https://github.com/iqlusioninc/ethers-rs.git", branch = "zaki/error_abi_support", features = ["abigen"] }
 clarity = "0.4.11"
 web30 = "0.15.4"

--- a/orchestrator/gorc/Cargo.toml
+++ b/orchestrator/gorc/Cargo.toml
@@ -18,7 +18,7 @@ gravity_utils = { path = "../gravity_utils" }
 orchestrator = { path = "../orchestrator" }
 relayer = { path = "../relayer" }
 
-deep_space = "2.4.7"
+deep_space = { git = "https://github.com/iqlusioninc/deep_space/", branch = "master" }
 ethers = { git = "https://github.com/iqlusioninc/ethers-rs.git", branch = "zaki/error_abi_support", features = ["abigen"] }
 clarity = "0.4.12"
 actix-rt = "2.5"

--- a/orchestrator/gravity_utils/Cargo.toml
+++ b/orchestrator/gravity_utils/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 gravity_abi = { path = "../gravity_abi" }
 gravity_proto = { path = "../gravity_proto/" }
 cosmos-sdk-proto = "0.6.3"
-deep_space = "2.4.7"
+deep_space = { git = "https://github.com/iqlusioninc/deep_space/", branch = "master" }
 ethers = { git = "https://github.com/iqlusioninc/ethers-rs.git", branch = "zaki/error_abi_support", features = ["abigen"] }
 web30 = "0.15"
 clarity = "0.4.11"

--- a/orchestrator/orchestrator/Cargo.toml
+++ b/orchestrator/orchestrator/Cargo.toml
@@ -16,7 +16,7 @@ gravity_abi = { path = "../gravity_abi" }
 gravity_utils = { path = "../gravity_utils" }
 gravity_proto = { path = "../gravity_proto" }
 
-deep_space = "2.4.7"
+deep_space = { git = "https://github.com/iqlusioninc/deep_space/", branch = "master" }
 ethers = { git = "https://github.com/iqlusioninc/ethers-rs.git", branch = "zaki/error_abi_support", features = ["abigen"] }
 serde_derive = "1.0"
 clarity = "0.4.11"

--- a/orchestrator/register_delegate_keys/Cargo.toml
+++ b/orchestrator/register_delegate_keys/Cargo.toml
@@ -15,7 +15,7 @@ cosmos_gravity = {path = "../cosmos_gravity"}
 gravity_utils = {path = "../gravity_utils"}
 gravity_proto = {path = "../gravity_proto/"}
 
-deep_space = "2.4.7"
+deep_space = { git = "https://github.com/iqlusioninc/deep_space/", branch = "master" }
 ethers = { git = "https://github.com/iqlusioninc/ethers-rs.git", branch = "zaki/error_abi_support", features = ["abigen"] }
 contact = "0.4"
 serde_derive = "1.0"

--- a/orchestrator/relayer/Cargo.toml
+++ b/orchestrator/relayer/Cargo.toml
@@ -19,7 +19,7 @@ gravity_abi = { path = "../gravity_abi" }
 gravity_utils = { path = "../gravity_utils" }
 gravity_proto = { path = "../gravity_proto" }
 
-deep_space = "2.4.7"
+deep_space = { git = "https://github.com/iqlusioninc/deep_space/", branch = "master" }
 ethers = { git = "https://github.com/iqlusioninc/ethers-rs.git", branch = "zaki/error_abi_support", features = ["abigen"] }
 serde_derive = "1.0"
 clarity = "0.4.11"

--- a/orchestrator/test_runner/Cargo.toml
+++ b/orchestrator/test_runner/Cargo.toml
@@ -17,7 +17,7 @@ gravity_utils = {path = "../gravity_utils"}
 gravity_proto = {path = "../gravity_proto/"}
 orchestrator = {path = "../orchestrator/"}
 
-deep_space = "2.4.7"
+deep_space = { git = "https://github.com/iqlusioninc/deep_space/", branch = "master" }
 serde_derive = "1.0"
 clarity = "0.4.11"
 docopt = "1"


### PR DESCRIPTION
Code that depends on `gravity_bridge` in external `Cargo.toml` files will not be able to correctly resolve the right version of `deep_space` with the setup using the patch directive in the workspace `Cargo.toml` file. This reverts that behavior and specifies the specific version of `deep_space` in each crate.