### PR TITLE
Register the community spend proposal correctly

### DIFF
--- a/module/x/gravity/client/cli/tx.go
+++ b/module/x/gravity/client/cli/tx.go
@@ -213,7 +213,7 @@ Where proposal.json contains:
 	"title": "Community Pool Ethereum Spend",
 	"description": "Bridge me some tokens to Ethereum!",
 	"recipient": "0x0000000000000000000000000000000000000000",
-	"amount": "20000stake"
+	"amount": "20000stake",
 	"bridge_fee": "1000stake",
 	"deposit": "1000stake"
 }

--- a/module/x/gravity/types/codec.go
+++ b/module/x/gravity/types/codec.go
@@ -9,6 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 )
 
 // RegisterLegacyAminoCodec registers the vesting interfaces and concrete types on the
@@ -70,6 +71,10 @@ func RegisterInterfaces(registry types.InterfaceRegistry) {
 		&SignerSetTx{},
 		&BatchTx{},
 		&ContractCallTx{},
+	)
+
+	registry.RegisterImplementations((*govtypes.Content)(nil),
+		&CommunityPoolEthereumSpendProposal{},
 	)
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)


### PR DESCRIPTION
There was a line of boilerplate in `codec.go` for registering the proposal type that wasn't implemented.