### PR TITLE
Test and fix community spend proposal

### DIFF
--- a/integration_tests/happy_path_test.go
+++ b/integration_tests/happy_path_test.go
@@ -6,6 +6,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/peggyjv/gravity-bridge/module/v2/x/gravity/types"
 )
@@ -100,7 +102,6 @@ func (s *IntegrationTestSuite) TestHappyPath() {
 		}, 105*time.Second, 10*time.Second, "balance never found on cosmos")
 
 		s.T().Logf("sending to ethereum")
-
 		sendToEthereumMsg := types.NewMsgSendToEthereum(
 			s.chain.validators[1].keyInfo.GetAddress(),
 			s.chain.validators[1].ethereumKey.address,
@@ -129,5 +130,100 @@ func (s *IntegrationTestSuite) TestHappyPath() {
 			return true
 		}, 105*time.Second, 10*time.Second, "unable to send to ethereum")
 
+		s.T().Logf("funding community pool")
+		orch := s.chain.orchestrators[0]
+		clientCtx, err := s.chain.clientContext("tcp://localhost:26657", orch.keyring, "orch", orch.keyInfo.GetAddress())
+		s.Require().NoError(err)
+
+		fundCommunityPoolMsg := distrtypes.NewMsgFundCommunityPool(
+			sdk.NewCoins(sdk.NewCoin(testDenom, sdk.NewInt(1000000000))),
+			orch.keyInfo.GetAddress(),
+		)
+
+		s.Require().Eventuallyf(func() bool {
+			response, err := s.chain.sendMsgs(*clientCtx, fundCommunityPoolMsg)
+			if err != nil {
+				s.T().Logf("error: %s", err)
+				return false
+			}
+			if response.Code != 0 {
+				if response.Code != 32 {
+					s.T().Log(response)
+				}
+				return false
+			}
+			return true
+		}, 105*time.Second, 10*time.Second, "unable to fund community pool")
+
+		distrQueryClient := distrtypes.NewQueryClient(clientCtx)
+		poolRes, err := distrQueryClient.CommunityPool(context.Background(),
+			&distrtypes.QueryCommunityPoolRequest{},
+		)
+		s.Require().NoError(err, "error retrieving community pool")
+		s.Require().True(poolRes.Pool.AmountOf(testDenom).GT(sdk.NewDec(1000000000)))
+
+		s.T().Logf("deploying testgb as an ERC20")
+		gbQueryClient := types.NewQueryClient(clientCtx)
+		paramsRes, err := gbQueryClient.DenomToERC20Params(context.Background(),
+			&types.DenomToERC20ParamsRequest{
+				Denom: testDenom,
+			})
+		s.Require().NoError(err, "error retrieving ERC20 params for testgb denom")
+
+		err = s.deployERC20(paramsRes.BaseDenom, paramsRes.Erc20Name, paramsRes.Erc20Symbol, uint8(paramsRes.Erc20Decimals))
+		s.Require().NoError(err, "error deploying testgb as an ERC20")
+
+		s.Require().Eventuallyf(func() bool {
+			erc20Res, err := gbQueryClient.DenomToERC20(context.Background(),
+				&types.DenomToERC20Request{
+					Denom: testDenom,
+				},
+			)
+			if err != nil {
+				s.T().Logf("error querying ERC20 for testgb denom: %s", err)
+				return false
+			}
+
+			s.Require().True(erc20Res.CosmosOriginated)
+			return true
+		}, 180*time.Second, 10*time.Second, "unable to verify ERC20 deployment")
+
+		s.T().Logf("create governance proposal to fund an ethereum address")
+		orch = s.chain.orchestrators[0]
+		clientCtx, err = s.chain.clientContext("tcp://localhost:26657", orch.keyring, "orch", orch.keyInfo.GetAddress())
+		s.Require().NoError(err)
+
+		proposal := types.CommunityPoolEthereumSpendProposal{
+			Title:       "community pool spend ethereum",
+			Description: "community pool spend ethereum",
+			Recipient:   s.chain.validators[1].ethereumKey.address,
+			Amount:      sdk.NewCoin(testDenom, sdk.NewInt(900000000)),
+			BridgeFee:   sdk.NewCoin(testDenom, sdk.NewInt(1000000)),
+		}
+
+		proposalMsg, err := govtypes.NewMsgSubmitProposal(
+			&proposal,
+			sdk.Coins{
+				{
+					Denom:  testDenom,
+					Amount: sdk.NewInt(2),
+				},
+			},
+			orch.keyInfo.GetAddress(),
+		)
+		s.Require().NoError(err, "unable to create governance proposal")
+
+		s.T().Log("submit proposal spending community pool funds")
+		submitProposalResponse, err := s.chain.sendMsgs(*clientCtx, proposalMsg)
+		s.Require().NoError(err)
+		s.Require().Zero(submitProposalResponse.Code, "raw log: %s", submitProposalResponse.RawLog)
+
+		s.T().Log("check proposal was submitted correctly")
+		govQueryClient := govtypes.NewQueryClient(clientCtx)
+		proposalsQueryResponse, err := govQueryClient.Proposals(context.Background(), &govtypes.QueryProposalsRequest{})
+		s.Require().NoError(err)
+		s.Require().NotEmpty(proposalsQueryResponse.Proposals)
+		s.Require().Equal(uint64(1), proposalsQueryResponse.Proposals[0].ProposalId, "not proposal id 1")
+		s.Require().Equal(govtypes.StatusVotingPeriod, proposalsQueryResponse.Proposals[0].Status, "proposal not in voting period")
 	})
 }

--- a/integration_tests/setup_test.go
+++ b/integration_tests/setup_test.go
@@ -738,7 +738,7 @@ func (s *IntegrationTestSuite) sendToCosmos(destination sdk.AccAddress, amount s
 	return s.SendEthTransaction(s.chain.validators[0], gravityContract, PackSendToCosmos(testERC20contract, destination, amount))
 }
 
-func (s *IntegrationTestSuite) getEthBalanceOf(account common.Address) (*sdk.Int, error) {
+func (s *IntegrationTestSuite) getEthTokenBalanceOf(account common.Address, erc20contract common.Address) (*sdk.Int, error) {
 	ethClient, err := ethclient.Dial(fmt.Sprintf("http://%s", s.ethResource.GetHostPort("8545/tcp")))
 	if err != nil {
 		return nil, err
@@ -748,7 +748,7 @@ func (s *IntegrationTestSuite) getEthBalanceOf(account common.Address) (*sdk.Int
 
 	response, err := ethClient.CallContract(context.Background(), ethereum.CallMsg{
 		From: common.HexToAddress(s.chain.validators[0].ethereumKey.address),
-		To:   &testERC20contract,
+		To:   &erc20contract,
 		Gas:  0,
 		Data: data,
 	}, nil)

--- a/module/app/app.go
+++ b/module/app/app.go
@@ -371,24 +371,6 @@ func NewGravityApp(
 		scopedIBCKeeper,
 	)
 
-	govRouter := govtypes.NewRouter()
-	govRouter.AddRoute(govtypes.RouterKey, govtypes.ProposalHandler).
-		AddRoute(paramsproposal.RouterKey, params.NewParamChangeProposalHandler(app.paramsKeeper)).
-		AddRoute(distrtypes.RouterKey, distr.NewCommunityPoolSpendProposalHandler(app.distrKeeper)).
-		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(app.upgradeKeeper)).
-		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.ibcKeeper.ClientKeeper)).
-		AddRoute(gravitytypes.RouterKey, gravity.NewCommunityPoolEthereumSpendProposalHandler(app.gravityKeeper))
-
-	app.govKeeper = govkeeper.NewKeeper(
-		appCodec,
-		keys[govtypes.StoreKey],
-		app.GetSubspace(govtypes.ModuleName),
-		app.accountKeeper,
-		app.bankKeeper,
-		&stakingKeeper,
-		govRouter,
-	)
-
 	app.transferKeeper = ibctransferkeeper.NewKeeper(
 		appCodec, keys[ibctransfertypes.StoreKey], app.GetSubspace(ibctransfertypes.ModuleName),
 		app.ibcKeeper.ChannelKeeper, &app.ibcKeeper.PortKeeper,
@@ -420,6 +402,24 @@ func NewGravityApp(
 		sdk.DefaultPowerReduction,
 		app.ModuleAccountAddressesToNames([]string{}),
 		app.ModuleAccountAddressesToNames([]string{distrtypes.ModuleName}),
+	)
+
+	govRouter := govtypes.NewRouter()
+	govRouter.AddRoute(govtypes.RouterKey, govtypes.ProposalHandler).
+		AddRoute(paramsproposal.RouterKey, params.NewParamChangeProposalHandler(app.paramsKeeper)).
+		AddRoute(distrtypes.RouterKey, distr.NewCommunityPoolSpendProposalHandler(app.distrKeeper)).
+		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(app.upgradeKeeper)).
+		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.ibcKeeper.ClientKeeper)).
+		AddRoute(gravitytypes.RouterKey, gravity.NewCommunityPoolEthereumSpendProposalHandler(app.gravityKeeper))
+
+	app.govKeeper = govkeeper.NewKeeper(
+		appCodec,
+		keys[govtypes.StoreKey],
+		app.GetSubspace(govtypes.ModuleName),
+		app.accountKeeper,
+		app.bankKeeper,
+		&stakingKeeper,
+		govRouter,
 	)
 
 	app.setupUpgradeStoreLoaders()

--- a/module/x/gravity/keeper/proposal_handler.go
+++ b/module/x/gravity/keeper/proposal_handler.go
@@ -13,7 +13,8 @@ func (k Keeper) HandleCommunityPoolEthereumSpendProposal(ctx sdk.Context, p *typ
 	// NOTE the community pool isn't a module account, however its coins
 	// are held in the distribution module account. Thus the community pool
 	// must be reduced separately from the createSendToEthereum calls
-	newPool, negative := feePool.CommunityPool.SafeSub(sdk.NewDecCoinsFromCoins(p.Amount, p.BridgeFee))
+	totalToSpend := p.Amount.Add(p.BridgeFee)
+	newPool, negative := feePool.CommunityPool.SafeSub(sdk.NewDecCoinsFromCoins(totalToSpend))
 	if negative {
 		return distributiontypes.ErrBadDistribution
 	}

--- a/orchestrator/relayer/src/logic_call_relaying.rs
+++ b/orchestrator/relayer/src/logic_call_relaying.rs
@@ -4,8 +4,11 @@ use ethereum_gravity::one_eth_f32;
 use ethereum_gravity::{
     logic_call::send_eth_logic_call, types::EthClient, utils::get_logic_call_nonce,
 };
+use ethers::prelude::ContractError;
+use ethers::prelude::signer::SignerMiddlewareError;
 use ethers::types::Address as EthAddress;
 use gravity_proto::gravity::query_client::QueryClient as GravityQueryClient;
+use gravity_utils::error::GravityError;
 use gravity_utils::ethereum::{bytes_to_hex_str, downcast_to_f32};
 use gravity_utils::types::{LogicCallConfirmResponse, Valset};
 use gravity_utils::{message_signatures::encode_logic_call_confirm_hashed, types::LogicCall};
@@ -38,6 +41,10 @@ pub async fn relay_logic_calls(
     let mut oldest_signatures: Option<Vec<LogicCallConfirmResponse>> = None;
     for call in latest_calls {
         if logic_call_skips.should_skip(&call) {
+            warn!(
+                "Skipping LogicCall {}/{}, will be skipped until on-chain timeout at eth height {} or process restart",
+                bytes_to_hex_str(&call.invalidation_id), call.invalidation_nonce, call.timeout
+            );
             continue;
         }
 


### PR DESCRIPTION
* Fix keeper ordering sending a null keeper to the proposal handler
* Fix panicking `NewDecCoinsFromCoins` by adding the coins together to avoid a duplicate denom error
* Add deploy ERC20 and the community spend proposal to the happy path integration test
* Add a detailed logging message around logic call skips