### PR TITLE
Search for oracle events in chunks

### DIFF
--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -2227,7 +2227,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "gorc"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",
@@ -3252,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "orchestrator"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "actix-rt 2.5.0",
  "axum",

--- a/orchestrator/gorc/Cargo.toml
+++ b/orchestrator/gorc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gorc"
 authors = []
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.58"
 

--- a/orchestrator/orchestrator/Cargo.toml
+++ b/orchestrator/orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 

--- a/orchestrator/orchestrator/src/main_loop.rs
+++ b/orchestrator/orchestrator/src/main_loop.rs
@@ -211,6 +211,7 @@ pub async fn eth_oracle_main_loop(
                     gravity_contract_address,
                     cosmos_key,
                     last_checked_block,
+                    blocks_to_search.into(),
                     block_delay,
                     msg_sender.clone(),
                 )


### PR DESCRIPTION
If it has been a long time since the last confirmed event, in the existing code the oracle will try to search from that block to the latest block on the network. Depending on how far back that event is, it could be an enormous query. This change tries to chunk the search using our existing `blocks_to_search` config value. The `check_for_events` function will now only search that number of blocks forward, or to the latest block if that range is shorter. When this function successfully returns with `Ok(ending_block)`, the outer loop should set that as the new `last_checked_block` and move to the next chunk when the loop next iterates (the included code window is scrollable if it doesn't show the whole thing):

https://github.com/PeggyJV/gravity-bridge/blob/ed557f4b1e8f18f9817d86cf224cafb27ab921f9/orchestrator/orchestrator/src/main_loop.rs#L206-L219