### PR TITLE
Fix gen-tx cmd

### DIFF
--- a/module/cmd/gravity/cmd/gentx.go
+++ b/module/cmd/gravity/cmd/gentx.go
@@ -154,6 +154,10 @@ $ %s gentx my-key-name 1000000stake 0x033030FEeBd93E3178487c35A9c8cA80874353C9 c
 				return errors.Wrap(err, "error creating tx builder")
 			}
 
+			if createValCfg.NodeID != "" && createValCfg.IP != "" {
+				txFactory = txFactory.WithMemo(fmt.Sprintf("%s@%s:26656", createValCfg.NodeID, createValCfg.IP))
+			}
+
 			clientCtx = clientCtx.WithInput(inBuf).WithFromAddress(key.GetAddress())
 
 			// The following line comes from a discrepancy between the `gentx`


### PR DESCRIPTION
The `gen-tx` cmd from cosmos-sdk generate messages specifying in the memo the validator address ip and node id 

https://github.com/cosmos/cosmos-sdk/blob/main/x/staking/client/cli/tx.go#L616

in the `collect-tx`, the memo is checked and rejected if it cannot find the validator network information

https://github.com/cosmos/cosmos-sdk/blob/main/x/genutil/collect.go#L128


Since the `gen-tx` cmd is overidden in gravity bridge, we need to follow the same logic and append the memo