### PR TITLE
Fix mistake on slashing logic

### DIFF
--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -366,7 +366,7 @@ func outgoingTxSlashing(ctx sdk.Context, k keeper.Keeper) {
 			for _, valInfo := range unbondingValInfos {
 				// Only slash validators who joined after valset is created and they are
 				// unbonding and UNBOND_SLASHING_WINDOW didn't pass.
-				if valInfo.exist && valInfo.sigs.StartHeight < int64(sstx.Nonce) &&
+				if valInfo.exist && valInfo.sigs.StartHeight < int64(sstx.Height) &&
 					valInfo.val.IsUnbonding() &&
 					sstx.Height < uint64(valInfo.val.UnbondingHeight)+params.UnbondSlashingSignerSetTxsWindow {
 					// check if validator has confirmed valset or not


### PR DESCRIPTION
Comparison should be on the height.

This would cause unbounded validator not getting slashed for not signing during the unbound period