### PR TITLE
Specify gas limit multiplier for relaying

### DIFF
--- a/orchestrator/ethereum_gravity/src/logic_call.rs
+++ b/orchestrator/ethereum_gravity/src/logic_call.rs
@@ -72,7 +72,8 @@ pub async fn send_eth_logic_call(
 
     let contract_call = contract_call
         .gas(gas_cost.gas)
-        .gas_price(gas_cost.gas_price);
+        .gas_price(gas_cost.gas_price)
+        .legacy(); // must submit transactions as legacy due to bug in manually-specified EIP1559 gas limits
 
     let pending_tx = contract_call.send().await?;
     let tx_hash = *pending_tx;

--- a/orchestrator/ethereum_gravity/src/submit_batch.rs
+++ b/orchestrator/ethereum_gravity/src/submit_batch.rs
@@ -64,7 +64,8 @@ pub async fn send_eth_transaction_batch(
 
     let contract_call = contract_call
         .gas(gas_cost.gas)
-        .gas_price(gas_cost.gas_price);
+        .gas_price(gas_cost.gas_price)
+        .legacy(); // must submit transactions as legacy due to bug in manually-specified EIP1559 gas limits
 
     let pending_tx = contract_call.send().await?;
     let tx_hash = *pending_tx;

--- a/orchestrator/ethereum_gravity/src/valset_update.rs
+++ b/orchestrator/ethereum_gravity/src/valset_update.rs
@@ -50,7 +50,8 @@ pub async fn send_eth_valset_update(
     )?;
     let contract_call = contract_call
         .gas(gas_cost.gas)
-        .gas_price(gas_cost.gas_price);
+        .gas_price(gas_cost.gas_price)
+        .legacy(); // must submit transactions as legacy due to bug in manually-specified EIP1559 gas limits
 
     let pending_tx = contract_call.send().await?;
     let tx_hash = *pending_tx;

--- a/orchestrator/gorc/src/commands/orchestrator/start.rs
+++ b/orchestrator/gorc/src/commands/orchestrator/start.rs
@@ -108,6 +108,7 @@ impl Runnable for StartCommand {
                 gas_price,
                 &config.metrics.listen_addr,
                 config.ethereum.gas_price_multiplier,
+                config.ethereum.gas_multiplier,
                 config.ethereum.blocks_to_search,
                 config.cosmos.gas_adjustment,
                 self.orchestrator_only,

--- a/orchestrator/gorc/src/config.rs
+++ b/orchestrator/gorc/src/config.rs
@@ -74,6 +74,7 @@ pub struct EthereumSection {
     pub key_derivation_path: String,
     pub rpc: String,
     pub gas_price_multiplier: f32,
+    pub gas_multiplier: f32,
     pub blocks_to_search: u64,
 }
 
@@ -83,6 +84,7 @@ impl Default for EthereumSection {
             key_derivation_path: "m/44'/60'/0'/0/0".to_owned(),
             rpc: "http://localhost:8545".to_owned(),
             gas_price_multiplier: 1.0f32,
+            gas_multiplier: 1.0f32,
             blocks_to_search: 5000,
         }
     }

--- a/orchestrator/orchestrator/src/main_loop.rs
+++ b/orchestrator/orchestrator/src/main_loop.rs
@@ -55,6 +55,7 @@ pub async fn orchestrator_main_loop(
     gas_price: (f64, String),
     metrics_listen: &net::SocketAddr,
     eth_gas_price_multiplier: f32,
+    eth_gas_multiplier: f32,
     blocks_to_search: u64,
     gas_adjustment: f64,
     relayer_opt_out: bool,
@@ -98,6 +99,7 @@ pub async fn orchestrator_main_loop(
             grpc_client.clone(),
             gravity_contract_address,
             eth_gas_price_multiplier,
+            eth_gas_multiplier,
         );
         futures::future::join5(a, b, c, d, e).await;
     } else {

--- a/orchestrator/relayer/src/logic_call_relaying.rs
+++ b/orchestrator/relayer/src/logic_call_relaying.rs
@@ -24,6 +24,7 @@ pub async fn relay_logic_calls(
     gravity_id: String,
     timeout: Duration,
     eth_gas_price_multiplier: f32,
+    eth_gas_multiplier: f32,
     logic_call_skips: &mut LogicCallSkips,
 ) {
     let latest_calls = match get_latest_logic_calls(grpc_client).await {
@@ -141,6 +142,7 @@ pub async fn relay_logic_calls(
         }
         let total_cost = total_cost.unwrap();
         let gas_price_as_f32 = downcast_to_f32(cost.gas_price).unwrap(); // if the total cost isn't greater, this isn't
+        let gas_as_f32 = downcast_to_f32(cost.gas).unwrap(); // same as above re: total cost
 
         info!(
             "We have detected latest LogicCall {} but latest on Ethereum is {} This LogicCall is estimated to cost {} Gas / {:.4} ETH to submit",
@@ -151,6 +153,7 @@ pub async fn relay_logic_calls(
         );
 
         cost.gas_price = ((gas_price_as_f32 * eth_gas_price_multiplier) as u128).into();
+        cost.gas = ((gas_as_f32 * eth_gas_multiplier) as u128).into();
 
         let res = send_eth_logic_call(
             current_valset,

--- a/orchestrator/relayer/src/main.rs
+++ b/orchestrator/relayer/src/main.rs
@@ -110,6 +110,7 @@ async fn main() {
         connections.grpc.unwrap(),
         gravity_contract_address,
         1f32,
+        1f32,
     )
     .await
 }

--- a/orchestrator/relayer/src/main.rs
+++ b/orchestrator/relayer/src/main.rs
@@ -109,8 +109,8 @@ async fn main() {
         eth_client,
         connections.grpc.unwrap(),
         gravity_contract_address,
-        1f32,
-        1f32,
+        1.1f32,
+        1.1f32,
     )
     .await
 }

--- a/orchestrator/relayer/src/main_loop.rs
+++ b/orchestrator/relayer/src/main_loop.rs
@@ -18,6 +18,7 @@ pub async fn relayer_main_loop(
     grpc_client: GravityQueryClient<Channel>,
     gravity_contract_address: EthAddress,
     eth_gas_price_multiplier: f32,
+    eth_gas_multiplier: f32,
 ) {
     let mut grpc_client = grpc_client;
     let gravity_id = get_gravity_id(gravity_contract_address, eth_client.clone()).await;
@@ -50,6 +51,8 @@ pub async fn relayer_main_loop(
                     gravity_contract_address,
                     gravity_id.clone(),
                     LOOP_SPEED,
+                    eth_gas_price_multiplier,
+                    eth_gas_multiplier,
                 )
                 .await;
 
@@ -61,6 +64,7 @@ pub async fn relayer_main_loop(
                     gravity_id.clone(),
                     LOOP_SPEED,
                     eth_gas_price_multiplier,
+                    eth_gas_multiplier,
                 )
                 .await;
 
@@ -72,6 +76,7 @@ pub async fn relayer_main_loop(
                     gravity_id.clone(),
                     LOOP_SPEED,
                     eth_gas_price_multiplier,
+                    eth_gas_multiplier,
                     &mut logic_call_skips,
                 )
                 .await;

--- a/orchestrator/relayer/src/main_loop.rs
+++ b/orchestrator/relayer/src/main_loop.rs
@@ -9,6 +9,7 @@ use std::{time::Duration};
 use tonic::transport::Channel;
 
 pub const LOOP_SPEED: Duration = Duration::from_secs(17);
+pub const PENDING_TX_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// This function contains the orchestrator primary loop, it is broken out of the main loop so that
 /// it can be called in the test runner for easier orchestration of multi-node tests
@@ -50,7 +51,7 @@ pub async fn relayer_main_loop(
                     &mut grpc_client,
                     gravity_contract_address,
                     gravity_id.clone(),
-                    LOOP_SPEED,
+                    PENDING_TX_TIMEOUT,
                     eth_gas_price_multiplier,
                     eth_gas_multiplier,
                 )
@@ -62,7 +63,7 @@ pub async fn relayer_main_loop(
                     &mut grpc_client,
                     gravity_contract_address,
                     gravity_id.clone(),
-                    LOOP_SPEED,
+                    PENDING_TX_TIMEOUT,
                     eth_gas_price_multiplier,
                     eth_gas_multiplier,
                 )
@@ -74,7 +75,7 @@ pub async fn relayer_main_loop(
                     &mut grpc_client,
                     gravity_contract_address,
                     gravity_id.clone(),
-                    LOOP_SPEED,
+                    PENDING_TX_TIMEOUT,
                     eth_gas_price_multiplier,
                     eth_gas_multiplier,
                     &mut logic_call_skips,

--- a/orchestrator/relayer/src/valset_relaying.rs
+++ b/orchestrator/relayer/src/valset_relaying.rs
@@ -24,6 +24,8 @@ pub async fn relay_valsets(
     gravity_contract_address: EthAddress,
     gravity_id: String,
     timeout: Duration,
+    eth_gas_price_multiplier: f32,
+    eth_gas_multiplier: f32,
 ) {
     // we have to start with the current ethereum valset, we need to know what's currently
     // in the contract in order to determine if a new validator set is valid.
@@ -162,7 +164,7 @@ pub async fn relay_valsets(
             );
             return;
         }
-        let cost = cost.unwrap();
+        let mut cost = cost.unwrap();
         let total_cost = downcast_to_f32(cost.get_total());
         if total_cost.is_none() {
             error!(
@@ -172,6 +174,8 @@ pub async fn relay_valsets(
             return;
         }
         let total_cost = total_cost.unwrap();
+        let gas_price_as_f32 = downcast_to_f32(cost.gas_price).unwrap(); // if the total cost isn't greater, this isn't
+        let gas_as_f32 = downcast_to_f32(cost.gas).unwrap(); // same as above re: total cost
 
         info!(
            "We have detected latest valset {} but latest on Ethereum is {} This valset is estimated to cost {} Gas / {:.4} ETH to submit",
@@ -179,6 +183,9 @@ pub async fn relay_valsets(
             cost.gas_price.clone(),
             total_cost / one_eth_f32()
         );
+
+        cost.gas_price = ((gas_price_as_f32 * eth_gas_price_multiplier) as u128).into();
+        cost.gas = ((gas_as_f32 * eth_gas_multiplier) as u128).into();
 
         let relay_response = send_eth_valset_update(
             latest_cosmos_valset.clone(),


### PR DESCRIPTION
This adds a CLI option for specifying an Ethereum gas limit multiplier, and converts relay contract calls into legacy versions to account for a bug in ethers that does not respect manually set gas limits in EIP1559 transactions.

Note that manually specified gas limits will always be overwritten if the access list estimate is lower:

https://github.com/iqlusioninc/ethers-rs/blob/4959552eb667ed2c765f6c0123bb0b7352cf948e/ethers-providers/src/lib.rs#L183-L204