### PR TITLE
Add in Transaction Stress Test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -219,6 +219,7 @@ jobs:
         test_type: [
             "HappyPath",
             "ValsetUpdate",
+            "TransactionStress",
         ]
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ e2e_slow_loris:
 	@make -s e2e_validator_out
 	@make -s e2e_batch_stress
 	@make -s e2e_valset_stress
+	@make -s stress_test_transactions
 
 e2e_clean_slate:
 	@docker rm --force \

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,5 @@ e2e_happy_path: e2e_clean_slate
 e2e_valset_update: e2e_clean_slate
 	integration_tests/integration_tests.test -test.failfast -test.v -test.run IntegrationTestSuite -testify.m TestValsetUpdate || make -s fail
 
-stress_test_transactions: export TransactionStressTest=true
 stress_test_transactions: e2e_clean_slate
 	integration_tests/integration_tests.test -test.failfast -test.v -test.run IntegrationTestSuite -testify.m TestTransactionStress || make -s fail

--- a/Makefile
+++ b/Makefile
@@ -68,3 +68,6 @@ e2e_happy_path: e2e_clean_slate
 
 e2e_valset_update: e2e_clean_slate
 	integration_tests/integration_tests.test -test.failfast -test.v -test.run IntegrationTestSuite -testify.m TestValsetUpdate || make -s fail
+
+stress_test_transactions: e2e_clean_slate
+	integration_tests/integration_tests.test -test.failfast -test.v -test.run IntegrationTestSuite -testify.m TestTransactionStress || make -s fail

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ e2e_slow_loris:
 	@make -s e2e_validator_out
 	@make -s e2e_batch_stress
 	@make -s e2e_valset_stress
-	@make -s stress_test_transactions
+	@make -s e2e_transaction_stress
 
 e2e_clean_slate:
 	@docker rm --force \
@@ -70,5 +70,5 @@ e2e_happy_path: e2e_clean_slate
 e2e_valset_update: e2e_clean_slate
 	integration_tests/integration_tests.test -test.failfast -test.v -test.run IntegrationTestSuite -testify.m TestValsetUpdate || make -s fail
 
-stress_test_transactions: e2e_clean_slate
+e2e_transaction_stress: e2e_clean_slate
 	integration_tests/integration_tests.test -test.failfast -test.v -test.run IntegrationTestSuite -testify.m TestTransactionStress || make -s fail

--- a/Makefile
+++ b/Makefile
@@ -69,5 +69,6 @@ e2e_happy_path: e2e_clean_slate
 e2e_valset_update: e2e_clean_slate
 	integration_tests/integration_tests.test -test.failfast -test.v -test.run IntegrationTestSuite -testify.m TestValsetUpdate || make -s fail
 
+stress_test_transactions: export TransactionStressTest=true
 stress_test_transactions: e2e_clean_slate
 	integration_tests/integration_tests.test -test.failfast -test.v -test.run IntegrationTestSuite -testify.m TestTransactionStress || make -s fail

--- a/integration_tests/setup_test.go
+++ b/integration_tests/setup_test.go
@@ -66,7 +66,7 @@ var (
 
 type IntegrationTestSuite struct {
 	suite.Suite
-
+	
 	chain         *chain
 	dockerPool    *dockertest.Pool
 	dockerNetwork *dockertest.Network
@@ -92,6 +92,17 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	mnemonics := MNEMONICS()
 	s.initNodesWithMnemonics(mnemonics...)
 	s.initEthereumFromMnemonics(mnemonics)
+
+	// TODO Add genisis creation for 100 mnemonics for stress testing.
+	// addGenesisAccount
+	fmt.Println("---------------------------------")
+	fmt.Println("TransactionStressTest:", os.Getenv("TransactionStressTest"))
+	if os.Getenv("TransactionStressTest") == "true" {
+		fmt.Println("we did it")
+	}
+	fmt.Println("---------------------------------")
+
+
 	s.initGenesis()
 	s.initValidatorConfigs()
 

--- a/integration_tests/setup_test.go
+++ b/integration_tests/setup_test.go
@@ -66,7 +66,7 @@ var (
 
 type IntegrationTestSuite struct {
 	suite.Suite
-	
+
 	chain         *chain
 	dockerPool    *dockertest.Pool
 	dockerNetwork *dockertest.Network

--- a/integration_tests/setup_test.go
+++ b/integration_tests/setup_test.go
@@ -751,15 +751,15 @@ func (s *IntegrationTestSuite) TestBasicChain() {
 }
 
 func (s *IntegrationTestSuite) deployERC20(denom string, name string, symbol string, decimals uint8) error {
-	return s.SendEthTransaction(s.chain.validators[0], gravityContract, PackDeployERC20(denom, name, symbol, decimals))
+	return s.SendEthTransaction(&s.chain.validators[0].ethereumKey, gravityContract, PackDeployERC20(denom, name, symbol, decimals))
 }
 
 func (s *IntegrationTestSuite) approveERC20() error {
-	return s.SendEthTransaction(s.chain.validators[0], testERC20contract, PackApproveERC20(gravityContract))
+	return s.SendEthTransaction(&s.chain.validators[0].ethereumKey, testERC20contract, PackApproveERC20(gravityContract))
 }
 
 func (s *IntegrationTestSuite) sendToCosmos(destination sdk.AccAddress, amount sdk.Int) error {
-	return s.SendEthTransaction(s.chain.validators[0], gravityContract, PackSendToCosmos(testERC20contract, destination, amount))
+	return s.SendEthTransaction(&s.chain.validators[0].ethereumKey, gravityContract, PackSendToCosmos(testERC20contract, destination, amount))
 }
 
 func (s *IntegrationTestSuite) getEthTokenBalanceOf(account common.Address, erc20contract common.Address) (*sdk.Int, error) {
@@ -808,13 +808,13 @@ func (s *IntegrationTestSuite) getERC20AllowanceOf(owner common.Address, spender
 	return &allowance, err
 }
 
-func (s *IntegrationTestSuite) SendEthTransaction(validator *validator, toAddress common.Address, data []byte) error {
+func (s *IntegrationTestSuite) SendEthTransaction(ethereumKey *ethereumKey, toAddress common.Address, data []byte) error {
 	ethClient, err := ethclient.Dial(fmt.Sprintf("http://%s", s.ethResource.GetHostPort("8545/tcp")))
 	if err != nil {
 		return err
 	}
 
-	privateKey, err := crypto.HexToECDSA(validator.ethereumKey.privateKey[2:])
+	privateKey, err := crypto.HexToECDSA(ethereumKey.privateKey[2:])
 	if err != nil {
 		return err
 	}

--- a/integration_tests/transaction_stress_test.go
+++ b/integration_tests/transaction_stress_test.go
@@ -2,13 +2,21 @@ package integration_tests
 
 // package imports
 import (
+	"context"
 	"fmt"
 	"os"
+	"crypto/ecdsa"
+	"math/big"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // We can add more erc20's, however testgb is already set up and theoretically solely viable for stress testing tx's
-var erc20_addresses = [...]string{"testgb"}
+var erc20s = [...]string{"testgb"}
 
 func (s *IntegrationTestSuite) TestTransactionStress() {
 	os.Setenv("TransactionStressTest", "true")
@@ -17,7 +25,46 @@ func (s *IntegrationTestSuite) TestTransactionStress() {
 		fmt.Println("StressTestTransaction starting")
 
 		// Check that eth test addresses have expected funds
+		for _, acct := range stress_test_eth_addresses {
+			balance, err := s.getEthTokenBalanceOf(common.HexToAddress(acct.address), testERC20contract)
+			s.Require().NoError(err, "error getting balance")
+			s.Require().Equal(sdk.NewUint(10000).BigInt(), balance.BigInt(), "balance was %s, expected 10000", balance.String())	
+		}
+
+		// Send many tx's through to cosmos
+		for _, acct := range stress_test_eth_addresses {
+			s.T().Logf("sending to cosmos..")
+
+			ethClient, err := ethclient.Dial(fmt.Sprintf("http://%s", s.ethResource.GetHostPort("8545/tcp")))
+			s.Require().NoError(err)
 		
+			privateKey, err := crypto.HexToECDSA(acct.privateKey[2:])
+			s.Require().NoError(err)
+		
+			publicKey := privateKey.Public()
+			publicKeyECDSA, _ := publicKey.(*ecdsa.PublicKey)
+		
+			fromAddress := crypto.PubkeyToAddress(*publicKeyECDSA)
+			nonce, err := ethClient.PendingNonceAt(context.Background(), fromAddress)
+			s.Require().NoError(err)
+
+			value := big.NewInt(0)
+			gasLimit := uint64(1000000)
+			gasPrice, err := ethClient.SuggestGasPrice(context.Background())
+			s.Require().NoError(err)
+
+			// Send to existing validator
+			tx := types.NewTransaction(nonce, gravityContract, value, gasLimit, gasPrice, PackSendToCosmos(testERC20contract, s.chain.validators[1].keyInfo.GetAddress(), sdk.NewInt(200)))
+		
+			chainID, err := ethClient.NetworkID(context.Background())
+			s.Require().NoError(err)
+
+			signedTx, err := types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
+			s.Require().NoError(err)
+
+			err = ethClient.SendTransaction(context.Background(), signedTx)
+			s.Require().NoError(err)
+		}
 
 		fmt.Println("StressTestTransaction completed successfully")
 	})

--- a/integration_tests/transaction_stress_test.go
+++ b/integration_tests/transaction_stress_test.go
@@ -3,14 +3,10 @@ package integration_tests
 // package imports
 import (
 	"fmt"
-	"time"
 	"os"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/peggyjv/gravity-bridge/module/v2/x/gravity/types"
 )
 
-const NUM_USERS int = 100
 // We can add more erc20's, however testgb is already set up and theoretically solely viable for stress testing tx's
 var erc20_addresses = [...]string{"testgb"}
 
@@ -20,48 +16,8 @@ func (s *IntegrationTestSuite) TestTransactionStress() {
 	s.Run("Transaction stress test", func() {
 		fmt.Println("StressTestTransaction starting")
 
-		// Create 100 eth addresses to send funds from 
-		eth_addresses := make([]*ethereumKey, NUM_USERS)
-
-		for i := 0; i < 100; i++ {
-			mnemonic, err := createMnemonic()
-			s.Require().NoError(err)
-
-			eth_addresses[i], err = ethereumKeyFromMnemonic(mnemonic)
-			s.Require().NoError(err)
-
-			// Send ERC20(s) to each address
-			for _, denom := range erc20_addresses {
-				s.T().Logf("sending to ethereum")
-				sendToEthereumMsg := types.NewMsgSendToEthereum(
-					s.chain.validators[1].keyInfo.GetAddress(),
-					s.chain.validators[1].ethereumKey.address,
-					sdk.Coin{Denom: denom, Amount: sdk.NewInt(1000)},
-					sdk.Coin{Denom: denom, Amount: sdk.NewInt(1)},
-				)
+		// Check that eth test addresses have expected funds
 		
-				s.Require().Eventuallyf(func() bool {
-					val := s.chain.validators[1]
-					keyring, err := val.keyring()
-					s.Require().NoError(err)
-					clientCtx, err := s.chain.clientContext("tcp://localhost:26657", &keyring, "val", val.keyInfo.GetAddress())
-					s.Require().NoError(err)
-		
-					response, err := s.chain.sendMsgs(*clientCtx, sendToEthereumMsg)
-					if err != nil {
-						s.T().Logf("error: %s", err)
-						return false
-					}
-					if response.Code != 0 {
-						if response.Code != 32 {
-							s.T().Log(response)
-						}
-						return false
-					}
-					return true
-				}, 105*time.Second, 10*time.Second, "unable to send to ethereum")
-			}
-		}
 
 		fmt.Println("StressTestTransaction completed successfully")
 	})

--- a/integration_tests/transaction_stress_test.go
+++ b/integration_tests/transaction_stress_test.go
@@ -44,11 +44,10 @@ func (s *IntegrationTestSuite) TestTransactionStress() {
 		}
 
 		var gravityDenom string
-		for i := 0; i < len(s.chain.validators); i++ {
+		for i, validator := range s.chain.validators {
 			s.Require().Eventuallyf(func() bool {
 				s.T().Logf("Checking validator %d", i+1)
 
-				validator := s.chain.validators[i]
 				kb, err := validator.keyring()
 				s.Require().NoError(err)
 				clientCtx, err := s.chain.clientContext("tcp://localhost:26657", &kb, "val", validator.keyInfo.GetAddress())
@@ -90,11 +89,10 @@ func (s *IntegrationTestSuite) TestTransactionStress() {
 		}
 		fmt.Println("Ethereum -> Cosmos stress test completed.")
 
-		for i := 0; i < len(s.chain.validators); i++ {
+		for i, validator := range s.chain.validators {
 			s.Require().Eventuallyf(func() bool {
 				s.T().Logf("sending %d tx's to ethereum for validator %d ..", transactions_per_validator, i+1)
 
-				validator := s.chain.validators[i]
 				sendToEthereumMsg := types.NewMsgSendToEthereum(
 					validator.keyInfo.GetAddress(),
 					s.chain.validators[len(s.chain.validators)-1-i].ethereumKey.address,
@@ -126,11 +124,11 @@ func (s *IntegrationTestSuite) TestTransactionStress() {
 			}, 105*time.Second, 10*time.Second, "unable to send to ethereum")
 		}
 
-		for i := 0; i < len(s.chain.validators); i++ {
+		for i, validator := range s.chain.validators {
 			s.Require().Eventuallyf(func() bool {
 				s.T().Logf("Checking validator %d", i+1)
 
-				balance, err := s.getEthTokenBalanceOf(common.HexToAddress(s.chain.validators[i].ethereumKey.address), testERC20contract)
+				balance, err := s.getEthTokenBalanceOf(common.HexToAddress(validator.ethereumKey.address), testERC20contract)
 				s.Require().NoError(err, "error getting destination balance")
 
 				if balance.LT(sdk.NewInt(10000 - (cosmos_sent_amt * transactions_per_validator) + (eth_sent_amt * transactions_per_validator))) {

--- a/integration_tests/transaction_stress_test.go
+++ b/integration_tests/transaction_stress_test.go
@@ -3,15 +3,66 @@ package integration_tests
 // package imports
 import (
 	"fmt"
+	"time"
+	"os"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/peggyjv/gravity-bridge/module/v2/x/gravity/types"
 )
 
+const NUM_USERS int = 100
+// We can add more erc20's, however testgb is already set up and theoretically solely viable for stress testing tx's
+var erc20_addresses = [...]string{"testgb"}
 
 func (s *IntegrationTestSuite) TestTransactionStress() {
+	os.Setenv("TransactionStressTest", "true")
+
 	s.Run("Transaction stress test", func() {
+		fmt.Println("StressTestTransaction starting")
 
+		// Create 100 eth addresses to send funds from 
+		eth_addresses := make([]*ethereumKey, NUM_USERS)
 
-		fmt.Println("----------------------------------------------------")
-		fmt.Println("StressTestTransaction")
-		s.T().Log("----------------------------------------------------")
+		for i := 0; i < 100; i++ {
+			mnemonic, err := createMnemonic()
+			s.Require().NoError(err)
+
+			eth_addresses[i], err = ethereumKeyFromMnemonic(mnemonic)
+			s.Require().NoError(err)
+
+			// Send ERC20(s) to each address
+			for _, denom := range erc20_addresses {
+				s.T().Logf("sending to ethereum")
+				sendToEthereumMsg := types.NewMsgSendToEthereum(
+					s.chain.validators[1].keyInfo.GetAddress(),
+					s.chain.validators[1].ethereumKey.address,
+					sdk.Coin{Denom: denom, Amount: sdk.NewInt(1000)},
+					sdk.Coin{Denom: denom, Amount: sdk.NewInt(1)},
+				)
+		
+				s.Require().Eventuallyf(func() bool {
+					val := s.chain.validators[1]
+					keyring, err := val.keyring()
+					s.Require().NoError(err)
+					clientCtx, err := s.chain.clientContext("tcp://localhost:26657", &keyring, "val", val.keyInfo.GetAddress())
+					s.Require().NoError(err)
+		
+					response, err := s.chain.sendMsgs(*clientCtx, sendToEthereumMsg)
+					if err != nil {
+						s.T().Logf("error: %s", err)
+						return false
+					}
+					if response.Code != 0 {
+						if response.Code != 32 {
+							s.T().Log(response)
+						}
+						return false
+					}
+					return true
+				}, 105*time.Second, 10*time.Second, "unable to send to ethereum")
+			}
+		}
+
+		fmt.Println("StressTestTransaction completed successfully")
 	})
 }

--- a/integration_tests/transaction_stress_test.go
+++ b/integration_tests/transaction_stress_test.go
@@ -14,7 +14,8 @@ import (
 
 // We have 4 validators running so this totals to 100 tx's
 const transactions_per_validator int64 = 25
-const sent_amt int64 = 100
+const cosmos_sent_amt int64 = 100
+const eth_sent_amt int64 = 1
 
 func (s *IntegrationTestSuite) TestTransactionStress() {
 	s.Run("Transaction stress test", func() {
@@ -30,7 +31,7 @@ func (s *IntegrationTestSuite) TestTransactionStress() {
 			s.Require().Equal(sdk.NewUint(10000).BigInt(), balance.BigInt(), "balance was %s, expected 10000", balance.String())	
 		}
 
-		sendAmt := sdk.NewInt(sent_amt)
+		sendAmt := sdk.NewInt(cosmos_sent_amt)
 		// Send many tx's through to cosmos
 		for i := 0; i < len(s.chain.validators); i++ {
 			s.T().Logf("sending %d tx's to cosmos for validator %d ..", transactions_per_validator, i+1)
@@ -75,7 +76,7 @@ func (s *IntegrationTestSuite) TestTransactionStress() {
 				gravityDenom = denomRes.Denom
 
 				for _, coin := range res.Balances {
-					if coin.Denom == gravityDenom && coin.Amount.Equal(sdk.NewInt(sent_amt * transactions_per_validator)) {
+					if coin.Denom == gravityDenom && coin.Amount.Equal(sdk.NewInt(cosmos_sent_amt * transactions_per_validator)) {
 						s.T().Logf("Expected funds recieved for validator %d, balance: %v", i + 1, coin)
 						return true
 					}
@@ -88,7 +89,60 @@ func (s *IntegrationTestSuite) TestTransactionStress() {
 		}
 		fmt.Println("Ethereum -> Cosmos stress test completed.")
 
-	
+		for i := 0; i < len(s.chain.validators); i++ {
+			s.Require().Eventuallyf(func() bool {
+				s.T().Logf("sending %d tx's to ethereum for validator %d ..", transactions_per_validator, i+1)
+
+				validator := s.chain.validators[i]
+				sendToEthereumMsg := types.NewMsgSendToEthereum(
+					validator.keyInfo.GetAddress(),
+					s.chain.validators[len(s.chain.validators)-1-i].ethereumKey.address,
+					sdk.Coin{Denom: gravityDenom, Amount: sdk.NewInt(eth_sent_amt)},
+					sdk.Coin{Denom: gravityDenom, Amount: sdk.NewInt(1)},
+				)
+
+				keyring, err := validator.keyring()
+				s.Require().NoError(err)
+				clientCtx, err := s.chain.clientContext("tcp://localhost:26657", &keyring, "val", validator.keyInfo.GetAddress())
+				s.Require().NoError(err)
+
+				for j := 0; j < int(transactions_per_validator); j++ {
+					response, err := s.chain.sendMsgs(*clientCtx, sendToEthereumMsg)
+					if err != nil {
+						s.T().Logf("error: %s", err)
+						return false
+					}
+					if response.Code != 0 {
+						if response.Code != 32 {
+							s.T().Log(response)
+						}
+						return false
+					}
+				}
+
+				s.T().Logf("%d Tx sent.", transactions_per_validator)
+				return true
+			}, 105*time.Second, 10*time.Second, "unable to send to ethereum")
+		}
+
+		for i := 0; i < len(s.chain.validators); i++ {
+			s.Require().Eventuallyf(func() bool {
+				s.T().Logf("Checking validator %d", i+1)
+
+				balance, err := s.getEthTokenBalanceOf(common.HexToAddress(s.chain.validators[i].ethereumKey.address), testERC20contract)
+				s.Require().NoError(err, "error getting destination balance")
+
+				if balance.LT(sdk.NewInt(10000 - (cosmos_sent_amt * transactions_per_validator) + (eth_sent_amt * transactions_per_validator))) {
+					s.T().Logf("funds not received yet, dest balance: %s", balance.String())
+					return false
+				}
+				
+				s.T().Logf("Funds recieved for validator %d, current balance: %v", i+1, balance.String())
+				return true
+			}, time.Second*180, time.Second*10, "balance never found")
+		}
+		fmt.Println("Cosmos -> Ethereum stress test completed.")
+
 		fmt.Println("StressTestTransaction completed successfully")
 	})
 }

--- a/integration_tests/transaction_stress_test.go
+++ b/integration_tests/transaction_stress_test.go
@@ -2,15 +2,9 @@ package integration_tests
 
 // package imports
 import (
-	"context"
 	"fmt"
-	"crypto/ecdsa"
-	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -21,48 +15,23 @@ func (s *IntegrationTestSuite) TestTransactionStress() {
 	s.Run("Transaction stress test", func() {
 		fmt.Println("StressTestTransaction starting")
 
-		// Check that eth test addresses have expected funds
+		// Approve spend & check that eth test addresses have expected funds
 		for _, acct := range stress_test_eth_addresses {
+			err := s.SendEthTransaction(acct, testERC20contract, PackApproveERC20(gravityContract))
+			s.Require().NoError(err, "error approving spend")
+
 			balance, err := s.getEthTokenBalanceOf(common.HexToAddress(acct.address), testERC20contract)
 			s.Require().NoError(err, "error getting balance")
 			s.Require().Equal(sdk.NewUint(10000).BigInt(), balance.BigInt(), "balance was %s, expected 10000", balance.String())	
 		}
 
-		// TODO: need to approve spend first?
-
+		sendAmt := sdk.NewInt(200)
 		// Send many tx's through to cosmos
 		for _, acct := range stress_test_eth_addresses {
 			s.T().Logf("sending to cosmos..")
-
-			ethClient, err := ethclient.Dial(fmt.Sprintf("http://%s", s.ethResource.GetHostPort("8545/tcp")))
-			s.Require().NoError(err)
-		
-			privateKey, err := crypto.HexToECDSA(acct.privateKey[2:])
-			s.Require().NoError(err)
-		
-			publicKey := privateKey.Public()
-			publicKeyECDSA, _ := publicKey.(*ecdsa.PublicKey)
-		
-			fromAddress := crypto.PubkeyToAddress(*publicKeyECDSA)
-			nonce, err := ethClient.PendingNonceAt(context.Background(), fromAddress)
-			s.Require().NoError(err)
-
-			value := big.NewInt(0)
-			gasLimit := uint64(1000000)
-			gasPrice, err := ethClient.SuggestGasPrice(context.Background())
-			s.Require().NoError(err)
-
 			// Send to existing validator
-			tx := types.NewTransaction(nonce, gravityContract, value, gasLimit, gasPrice, PackSendToCosmos(testERC20contract, s.chain.validators[1].keyInfo.GetAddress(), sdk.NewInt(200)))
-		
-			chainID, err := ethClient.NetworkID(context.Background())
-			s.Require().NoError(err)
-
-			signedTx, err := types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
-			s.Require().NoError(err)
-
-			err = ethClient.SendTransaction(context.Background(), signedTx)
-			s.Require().NoError(err)
+			s.Require().NoError(s.SendEthTransaction(acct, gravityContract, PackSendToCosmos(testERC20contract, s.chain.validators[1].keyInfo.GetAddress(), sendAmt)))
+			s.T().Logf("Tx sent.")
 		}
 
 		fmt.Println("StressTestTransaction completed successfully")

--- a/integration_tests/transaction_stress_test.go
+++ b/integration_tests/transaction_stress_test.go
@@ -1,0 +1,17 @@
+package integration_tests
+
+// package imports
+import (
+	"fmt"
+)
+
+
+func (s *IntegrationTestSuite) TestTransactionStress() {
+	s.Run("Transaction stress test", func() {
+
+
+		fmt.Println("----------------------------------------------------")
+		fmt.Println("StressTestTransaction")
+		s.T().Log("----------------------------------------------------")
+	})
+}

--- a/integration_tests/transaction_stress_test.go
+++ b/integration_tests/transaction_stress_test.go
@@ -33,11 +33,11 @@ func (s *IntegrationTestSuite) TestTransactionStress() {
 
 		sendAmt := sdk.NewInt(cosmos_sent_amt)
 		// Send many tx's through to cosmos
-		for i := 0; i < len(s.chain.validators); i++ {
+		for i, validator := range s.chain.validators {
 			s.T().Logf("sending %d tx's to cosmos for validator %d ..", transactions_per_validator, i+1)
 
 			for j := 0; j < int(transactions_per_validator); j++ {
-				s.Require().NoError(s.SendEthTransaction(&s.chain.validators[i].ethereumKey, gravityContract, PackSendToCosmos(testERC20contract, s.chain.validators[len(s.chain.validators)-1-i].keyInfo.GetAddress(), sendAmt)))
+				s.Require().NoError(s.SendEthTransaction(&validator.ethereumKey, gravityContract, PackSendToCosmos(testERC20contract, s.chain.validators[len(s.chain.validators)-1-i].keyInfo.GetAddress(), sendAmt)))
 			}
 			
 			s.T().Logf("%d Tx sent.", transactions_per_validator)
@@ -60,6 +60,7 @@ func (s *IntegrationTestSuite) TestTransactionStress() {
 						Address: validator.keyInfo.GetAddress().String(),
 					})
 				if err != nil {
+					s.T().Logf("error: %s", err)
 					return false
 				}
 

--- a/integration_tests/transaction_stress_test.go
+++ b/integration_tests/transaction_stress_test.go
@@ -4,7 +4,6 @@ package integration_tests
 import (
 	"context"
 	"fmt"
-	"os"
 	"crypto/ecdsa"
 	"math/big"
 
@@ -19,8 +18,6 @@ import (
 var erc20s = [...]string{"testgb"}
 
 func (s *IntegrationTestSuite) TestTransactionStress() {
-	os.Setenv("TransactionStressTest", "true")
-
 	s.Run("Transaction stress test", func() {
 		fmt.Println("StressTestTransaction starting")
 
@@ -30,6 +27,8 @@ func (s *IntegrationTestSuite) TestTransactionStress() {
 			s.Require().NoError(err, "error getting balance")
 			s.Require().Equal(sdk.NewUint(10000).BigInt(), balance.BigInt(), "balance was %s, expected 10000", balance.String())	
 		}
+
+		// TODO: need to approve spend first?
 
 		// Send many tx's through to cosmos
 		for _, acct := range stress_test_eth_addresses {

--- a/integration_tests/transaction_stress_test.go
+++ b/integration_tests/transaction_stress_test.go
@@ -2,38 +2,93 @@ package integration_tests
 
 // package imports
 import (
+	"context"
+	"time"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/peggyjv/gravity-bridge/module/v2/x/gravity/types"
 )
 
-// We can add more erc20's, however testgb is already set up and theoretically solely viable for stress testing tx's
-var erc20s = [...]string{"testgb"}
+// We have 4 validators running so this totals to 100 tx's
+const transactions_per_validator int64 = 25
+const sent_amt int64 = 100
 
 func (s *IntegrationTestSuite) TestTransactionStress() {
 	s.Run("Transaction stress test", func() {
 		fmt.Println("StressTestTransaction starting")
 
-		// Approve spend & check that eth test addresses have expected funds
-		for _, acct := range stress_test_eth_addresses {
-			err := s.SendEthTransaction(acct, testERC20contract, PackApproveERC20(gravityContract))
+		// Approve spend & verify funds
+		for _, validator := range s.chain.validators {			
+			err := s.SendEthTransaction(&validator.ethereumKey, testERC20contract, PackApproveERC20(gravityContract))
 			s.Require().NoError(err, "error approving spend")
 
-			balance, err := s.getEthTokenBalanceOf(common.HexToAddress(acct.address), testERC20contract)
+			balance, err := s.getEthTokenBalanceOf(common.HexToAddress(validator.ethereumKey.address), testERC20contract)
 			s.Require().NoError(err, "error getting balance")
 			s.Require().Equal(sdk.NewUint(10000).BigInt(), balance.BigInt(), "balance was %s, expected 10000", balance.String())	
 		}
 
-		sendAmt := sdk.NewInt(200)
+		sendAmt := sdk.NewInt(sent_amt)
 		// Send many tx's through to cosmos
-		for _, acct := range stress_test_eth_addresses {
-			s.T().Logf("sending to cosmos..")
-			// Send to existing validator
-			s.Require().NoError(s.SendEthTransaction(acct, gravityContract, PackSendToCosmos(testERC20contract, s.chain.validators[1].keyInfo.GetAddress(), sendAmt)))
-			s.T().Logf("Tx sent.")
+		for i := 0; i < len(s.chain.validators); i++ {
+			s.T().Logf("sending %d tx's to cosmos for validator %d ..", transactions_per_validator, i+1)
+
+			for j := 0; j < int(transactions_per_validator); j++ {
+				s.Require().NoError(s.SendEthTransaction(&s.chain.validators[i].ethereumKey, gravityContract, PackSendToCosmos(testERC20contract, s.chain.validators[len(s.chain.validators)-1-i].keyInfo.GetAddress(), sendAmt)))
+			}
+			
+			s.T().Logf("%d Tx sent.", transactions_per_validator)
 		}
 
+		var gravityDenom string
+		for i := 0; i < len(s.chain.validators); i++ {
+			s.Require().Eventuallyf(func() bool {
+				s.T().Logf("Checking validator %d", i+1)
+
+				validator := s.chain.validators[i]
+				kb, err := validator.keyring()
+				s.Require().NoError(err)
+				clientCtx, err := s.chain.clientContext("tcp://localhost:26657", &kb, "val", validator.keyInfo.GetAddress())
+				s.Require().NoError(err)
+
+				bankQueryClient := banktypes.NewQueryClient(clientCtx)
+				res, err := bankQueryClient.AllBalances(context.Background(),
+					&banktypes.QueryAllBalancesRequest{
+						Address: validator.keyInfo.GetAddress().String(),
+					})
+				if err != nil {
+					return false
+				}
+
+				gbQueryClient := types.NewQueryClient(clientCtx)
+				denomRes, err := gbQueryClient.ERC20ToDenom(context.Background(),
+					&types.ERC20ToDenomRequest{
+						Erc20: testERC20contract.String(),
+					})
+				if err != nil {
+					s.T().Logf("error querying ERC20 denom %s, %e", testERC20contract.String(), err)
+					return false
+				}
+				s.Require().False(denomRes.CosmosOriginated, "ERC20-originated denom marked as cosmos originated")
+				gravityDenom = denomRes.Denom
+
+				for _, coin := range res.Balances {
+					if coin.Denom == gravityDenom && coin.Amount.Equal(sdk.NewInt(sent_amt * transactions_per_validator)) {
+						s.T().Logf("Expected funds recieved for validator %d, balance: %v", i + 1, coin)
+						return true
+					}
+				}
+
+				s.T().Logf("balance not found, received %v", res.Balances)
+
+				return false
+			}, 105*time.Second, 10*time.Second, "balance never found on cosmos")
+		}
+		fmt.Println("Ethereum -> Cosmos stress test completed.")
+
+	
 		fmt.Println("StressTestTransaction completed successfully")
 	})
 }


### PR DESCRIPTION
Sends funds from ethereum over to cosmos and then back again, 100 total tx's in each direction.

Initially the plan was to create new accounts but it was too painful to get working so I reused the validator addresses since they're all configured and good to go.