### PR TITLE
Move removal of data dir to end of teardown

### DIFF
--- a/integration_tests/setup_test.go
+++ b/integration_tests/setup_test.go
@@ -120,7 +120,6 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 
 	s.T().Log("tearing down e2e integration test suite...")
 
-	s.Require().NoError(os.RemoveAll(s.chain.dataDir))
 	s.Require().NoError(s.dockerPool.Purge(s.ethResource))
 
 	for _, vc := range s.valResources {
@@ -132,6 +131,7 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 	}
 
 	s.Require().NoError(s.dockerPool.RemoveNetwork(s.dockerNetwork))
+	s.Require().NoError(os.RemoveAll(s.chain.dataDir))
 }
 
 func (s *IntegrationTestSuite) initNodes(nodeCount int) {


### PR DESCRIPTION
Removing the data dir before taking down the Docker network fully can lead to scary "consensus errors" due to race conditions with file removal and node shutdown. This moves the deletion of the data dir to the end of teardown.