### PR TITLE
Prevent cosmos messaging getting stuck

### DIFF
--- a/integration_tests/setup_test.go
+++ b/integration_tests/setup_test.go
@@ -344,7 +344,7 @@ func (s *IntegrationTestSuite) initGenesis() {
 	s.Require().NoError(cdc.UnmarshalJSON(appGenState[gravitytypes.ModuleName], &gravityGenState))
 	gravityGenState.Params.GravityId = "gravitytest"
 	gravityGenState.Params.BridgeEthereumAddress = gravityContract.String()
-	gravityGenState.Params.SignedBatchesWindow = 15
+	gravityGenState.Params.SignedBatchesWindow = 35
 
 	bz, err = cdc.MarshalJSON(&gravityGenState)
 	s.Require().NoError(err)

--- a/module/app/app.go
+++ b/module/app/app.go
@@ -358,7 +358,7 @@ func NewGravityApp(
 		stakingtypes.NewMultiStakingHooks(
 			app.distrKeeper.Hooks(),
 			app.slashingKeeper.Hooks(),
-			app.gravityKeeper.Hooks(),
+			//app.gravityKeeper.Hooks(), TODO(bolten): this hook is broken, do not set it, to be fixed
 		),
 	)
 

--- a/orchestrator/cosmos_gravity/src/build.rs
+++ b/orchestrator/cosmos_gravity/src/build.rs
@@ -67,9 +67,9 @@ pub async fn batch_tx_confirmation_messages(
             ethereum_signer: format_eth_address(ethereum_address),
             signature: signature.into(),
         };
-        let msg = proto::MsgSubmitEthereumEvent {
+        let msg = proto::MsgSubmitEthereumTxConfirmation {
             signer: cosmos_address.to_string(),
-            event: confirmation.to_any(),
+            confirmation: confirmation.to_any(),
         };
         let msg = Msg::new("/gravity.v1.MsgSubmitEthereumTxConfirmation", msg);
         msgs.push(msg);

--- a/orchestrator/cosmos_gravity/src/send.rs
+++ b/orchestrator/cosmos_gravity/src/send.rs
@@ -175,6 +175,7 @@ pub async fn send_main_loop(
 ) {
     while let Some(messages) = rx.recv().await {
         for msg_chunk in messages.chunks(msg_batch_size) {
+            let batch = msg_chunk.to_vec();
             match send_messages(
                 contact,
                 cosmos_key,
@@ -184,21 +185,45 @@ pub async fn send_main_loop(
             )
             .await
             {
-                Ok(res) => trace!("okay: {:?}", res),
+                Ok(res) => debug!("message batch sent: {:?}", res),
                 Err(err) => {
-                    let msg_types = msg_chunk
-                        .iter()
-                        .map(|msg| prost_types::Any::from(msg.clone()).type_url)
-                        .collect::<HashSet<String>>();
+                    log_send_error(&batch, err);
 
-                    error!(
-                        "Error during gRPC call to Cosmos containing {} messages of types {:?}: {:?}",
-                        msg_chunk.len(),
-                        msg_types,
-                        err
-                    );
+                    // multiple messages in a single Cosmos transaction will be rejected
+                    // atomically if that transaction cannot be delivered, so retry each
+                    // element separately
+                    info!("Trying each message in batch individually");
+                    for msg in batch {
+                        let msg_vec = vec![msg];
+                        match send_messages(
+                            contact,
+                            cosmos_key,
+                            gas_price.to_owned(),
+                            msg_vec.clone(),
+                            gas_adjustment,
+                        )
+                        .await
+                        {
+                            Ok(res) => debug!("message sent: {:?}", res),
+                            Err(err) => {log_send_error(&msg_vec, err)}
+                        }
+                    }
                 }
             }
         }
     }
+}
+
+fn log_send_error(messages: &Vec<Msg>, err: GravityError) {
+    let msg_types = messages
+        .iter()
+        .map(|msg| prost_types::Any::from(msg.clone()).type_url)
+        .collect::<HashSet<String>>();
+
+    error!(
+        "Error during gRPC call to Cosmos containing {} messages of types {:?}: {:?}",
+        messages.len(),
+        msg_types,
+        err
+    );
 }

--- a/orchestrator/cosmos_gravity/src/send.rs
+++ b/orchestrator/cosmos_gravity/src/send.rs
@@ -205,7 +205,7 @@ pub async fn send_main_loop(
                         .await
                         {
                             Ok(res) => debug!("message sent: {:?}", res),
-                            Err(err) => {log_send_error(&msg_vec, err)}
+                            Err(err) => log_send_error(&msg_vec, err),
                         }
                     }
                 }


### PR DESCRIPTION
During stress testing, we observed certain conditions where the Ethereum oracle could get stuck based on the way messages were being chunked together: if the grouping of a chunk included a failed message with ones that should have succeeded, it could skip those valid messages. In this update, when a message batch fails atomically, each individual message from that batch will be retried individually. Thus, if a slow oracle pushes a set of failing messages (e.g. duplicates of previously sent messages) in front of ones that should succeed, it will still attempt to process them all and successfully move the recorded event nonce forward.

There are a few other fixes included here:

1. There was a clash between the transaction stress test and the validator out test -- the globally low value for the slashing signing window caused the transaction test to fail as validators begun getting jailed in the middle of it. This ups it to a number that allows both tests to run.
2. The validator out test was relying essentially on a race condition, where the very short jailing window would jail an orchestrator that failed to sign a message before the outgoing TX was removed from consideration by that batch successfully completing. This fixes that by removing two validators before the batch is sent, ensuring that it won't remove the TX by succeeding before the window to slash and jail the two offending validators has passed.
3. The hook for unbonding validators is broken (the example gravity chain here uses it, other implementers like Sommelier do not include this in their `app.go` currently), so it should be disabled for now until it is fixed. This is also the reason why unbonding validators were not triggering valset updates.
4. The incorrect proto was being built for confirming batches, but by chance the misnamed proto had the exact same field structure, so it worked nonetheless. This fixes it to the right proto.