### PR TITLE
Cargo version bumps

### DIFF
--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -2,7 +2,7 @@
 # Also, the name was changed from orchestrator to gravity_bridge.
 [package]
 name = "gravity_bridge"
-version = "0.1.0"
+version = "2.0.4"
 authors = ["PeggyJV"]
 license = "Apache-2.0"
 edition = "2018"

--- a/orchestrator/cosmos_gravity/Cargo.toml
+++ b/orchestrator/cosmos_gravity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmos_gravity"
-version = "0.1.0"
+version = "2.0.4"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 

--- a/orchestrator/gorc/Cargo.toml
+++ b/orchestrator/gorc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gorc"
 authors = []
-version = "2.0.1"
+version = "2.0.4"
 edition = "2021"
 rust-version = "1.58"
 

--- a/orchestrator/orchestrator/Cargo.toml
+++ b/orchestrator/orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator"
-version = "2.0.1"
+version = "2.0.4"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 


### PR DESCRIPTION
Bump cargo versions to 2.0.4 for affected packages.