### PR TITLE
Update unit test to use correct expected value

### DIFF
--- a/module/x/gravity/types/types_test.go
+++ b/module/x/gravity/types/types_test.go
@@ -29,7 +29,7 @@ func TestValsetConfirmHash(t *testing.T) {
 	// TODO: this is hardcoded to foo, replace?
 	hash := v.GetCheckpoint([]byte("foo"))
 	hexHash := hex.EncodeToString(hash)
-	correctHash := "0xaca2f283f21a03ba182dc7d34a55c04771b25087401d680011df7dcba453f798"[2:]
+	correctHash := "0x28677918928946680f0b059f632ae3c0f61d7006b6ece017adfec722ef5ca8a7"[2:]
 	assert.Equal(t, correctHash, hexHash)
 }
 


### PR DESCRIPTION
This PR changes the expected value for the `TestValsetConfirmHash` unit test.

The previous PR was mistakenly merged with a failing unit test. The unit test takes a valset, generates a checkpoint, and verifies the result matches an expected value. In order to ensure that the failure was due to an incorrect expected value and not an incorrect comparison implementation, I took the following steps:

It turns out that there is a very similar unit test in the `gravity_utils` crate that uses the same test values, but does no sorting. This made it easy to manually verify the expected value. I simply added sorting and checked the output hash, verifying that it matched the new actual value output by the Go unit test.

[The failing Go unit test](https://github.com/PeggyJV/gravity-bridge/blob/c8157e9cd567bf7ac11c0d3e546238922aaa3a64/module/x/gravity/types/types_test.go#L13-L34)

[The rust unit test with matching valset values](https://github.com/PeggyJV/gravity-bridge/blob/c8157e9cd567bf7ac11c0d3e546238922aaa3a64/orchestrator/gravity_utils/src/message_signatures.rs#L39-L80)

In the failing test log in CI, the expects/actual values are:
```
expected: "aca2f283f21a03ba182dc7d34a55c04771b25087401d680011df7dcba453f798"
actual : "28677918928946680f0b059f632ae3c0f61d7006b6ece017adfec722ef5ca8a7"
```

If we add the following lines to the rust test:
```rust
valset.members.sort(); // NEW
valset.members.reverse(); // NEW
let checkpoint = encode_valset_confirm("foo".to_string(), valset);
let checkpoint_hash = keccak256(&checkpoint);
println!("{:?}", bytes_to_hex_str(&checkpoint_hash)); // NEW
assert_eq!(correct_hash, checkpoint_hash);
```

And then run the test with the `--nocapture` flag:

```bash
# from within the gravity_utils crate
cargo test test_valset_signature -- --nocapture
```

The resulting checksum is:
`28677918928946680f0b059f632ae3c0f61d7006b6ece017adfec722ef5ca8a7`

which matches the actual value from our Go unit test.