### PR TITLE
Update http crate dependency

### DIFF
--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
  "http",
  "httparse",
  "indexmap",
- "itoa",
+ "itoa 0.4.7",
  "language-tags 0.2.2",
  "lazy_static",
  "log",
@@ -211,7 +211,7 @@ dependencies = [
  "h2 0.3.3",
  "http",
  "httparse",
- "itoa",
+ "itoa 0.4.7",
  "language-tags 0.3.2",
  "local-channel",
  "log",
@@ -700,7 +700,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "derive_more",
  "futures-core",
- "itoa",
+ "itoa 0.4.7",
  "log",
  "mime",
  "openssl",
@@ -2558,13 +2558,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.4"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
- "itoa",
+ "itoa 1.0.9",
 ]
 
 [[package]]
@@ -2611,7 +2611,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.7",
  "pin-project-lite 0.2.6",
  "socket2 0.4.9",
  "tokio 1.28.0",
@@ -2770,6 +2770,12 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jobserver"
@@ -4388,7 +4394,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
- "itoa",
+ "itoa 0.4.7",
  "ryu",
  "serde",
 ]
@@ -4400,7 +4406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.7",
  "ryu",
  "serde",
 ]


### PR DESCRIPTION
Steward is breaking in dev when I pull in a version of `somm_proto` that includes the pubsub bindings in the axelar-v2 branch. This is happening despite the fact that there is *no* diff between the lock files on `main` and `axelar-v2`:

```
error: failed to select a version for `http`.
    ... required by package `axum v0.6.9`
    ... which satisfies dependency `axum = "^0.6.9"` of package `tonic v0.9.0`
    ... which satisfies dependency `tonic = "^0.9"` of package `cosmos-sdk-proto v0.19.0 (http://github.com/cosmos/cosmos-rust?branch=main#aef5c708)`
    ... which satisfies git dependency `cosmos-sdk-proto` of package `somm_proto v5.0.0 (https://github.com/peggyjv/sommelier?branch=axelar-v2#fe273124)`
    ... which satisfies git dependency `somm_proto` of package `steward v3.0.0 (/Users/atro/source/work/steward)`
versions that meet the requirements `^0.2.9` are: 0.2.9

all possible versions conflict with previously selected packages.

  previously selected package `http v0.2.8`
    ... which satisfies dependency `http = "^0.2.0"` (locked to 0.2.8) of package `actix-connect v2.0.0`
    ... which satisfies dependency `actix-connect = "^2.0.0"` (locked to 2.0.0) of package `actix-http v2.2.2`
    ... which satisfies dependency `actix-http = "^2.2.0"` (locked to 2.2.2) of package `actix-web v3.3.3`
    ... which satisfies dependency `actix-web = "^3"` (locked to 3.3.3) of package `contact v0.4.2`
    ... which satisfies dependency `contact = "^0.4"` (locked to 0.4.2) of package `register_delegate_keys v2.0.0 (https://github.com/PeggyJV/gravity-bridge?branch=main#7ce6b3c1)`
    ... which satisfies git dependency `register_delegate_keys` (locked to 2.0.0) of package `gravity_bridge v2.0.4 (https://github.com/PeggyJV/gravity-bridge?branch=main#7ce6b3c1)`
    ... which satisfies git dependency `gravity_bridge` (locked to 2.0.4) of package `steward v3.0.0 (/Users/atro/source/work/steward)`

failed to select a version for `http` which could resolve this conflict
``` 

I've made this change locally so I can continue development, but wanted to go ahead and make a PR to reflect the change.