### PR TITLE
gravity_bridge/orchestrator/gorc/relayer to 4.0.0

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,6 +16,9 @@ env:
 
 jobs:
   rust-build:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout branch

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -1893,7 +1893,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gorc"
-version = "2.0.4"
+version = "4.0.0"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",
@@ -1947,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "gravity_bridge"
-version = "2.0.4"
+version = "4.0.0"
 dependencies = [
  "cosmos_gravity",
  "ethereum_gravity",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "orchestrator"
-version = "2.0.4"
+version = "4.0.0"
 dependencies = [
  "axum",
  "clarity",
@@ -3402,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "relayer"
-version = "2.0.0"
+version = "4.0.0"
 dependencies = [
  "actix",
  "clarity",

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -2,7 +2,7 @@
 # Also, the name was changed from orchestrator to gravity_bridge.
 [package]
 name = "gravity_bridge"
-version = "2.0.4"
+version = "4.0.0"
 authors = ["PeggyJV"]
 license = "Apache-2.0"
 edition = "2018"

--- a/orchestrator/gorc/Cargo.toml
+++ b/orchestrator/gorc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gorc"
 authors = []
-version = "2.0.4"
+version = "4.0.0"
 edition = "2021"
 rust-version = "1.63"
 

--- a/orchestrator/orchestrator/Cargo.toml
+++ b/orchestrator/orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator"
-version = "2.0.4"
+version = "4.0.0"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 

--- a/orchestrator/relayer/Cargo.toml
+++ b/orchestrator/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relayer"
-version = "2.0.0"
+version = "4.0.0"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 


### PR DESCRIPTION
Bump Cargo versions for 4.0 release.