### PR TITLE
Remove CompletedOutgoingTxs from unsigned batch and contract calls lookups

### DIFF
--- a/module/x/gravity/keeper/batch.go
+++ b/module/x/gravity/keeper/batch.go
@@ -163,17 +163,6 @@ func (k Keeper) getLastOutgoingBatchByTokenType(ctx sdk.Context, token common.Ad
 // GetUnsignedBatchTxs returns all batches for which the specified validator has not submitted confirmations in ascending nonce order
 func (k Keeper) GetUnsignedBatchTxs(ctx sdk.Context, val sdk.ValAddress) []*types.BatchTx {
 	var unconfirmed []*types.BatchTx
-	k.IterateCompletedOutgoingTxsByType(ctx, types.BatchTxPrefixByte, func(_ []byte, cotx types.OutgoingTx) bool {
-		sig := k.getEthereumSignature(ctx, cotx.GetStoreIndex(), val)
-		if len(sig) == 0 {
-			batch, ok := cotx.(*types.BatchTx)
-			if !ok {
-				panic(sdkerrors.Wrapf(types.ErrInvalid, "couldn't cast to batch tx for completed tx %s", cotx))
-			}
-			unconfirmed = append(unconfirmed, batch)
-		}
-		return false
-	})
 	k.IterateOutgoingTxsByType(ctx, types.BatchTxPrefixByte, func(_ []byte, otx types.OutgoingTx) bool {
 		sig := k.getEthereumSignature(ctx, otx.GetStoreIndex(), val)
 		if len(sig) == 0 {

--- a/module/x/gravity/keeper/batch_test.go
+++ b/module/x/gravity/keeper/batch_test.go
@@ -392,7 +392,8 @@ func TestGetUnconfirmedBatchTxs(t *testing.T) {
 
 	blockheight := uint64(ctx.BlockHeight())
 	sig := []byte("dummysig")
-	gk.SetCompletedOutgoingTx(ctx, &types.BatchTx{
+	//gk.SetCompletedOutgoingTx(ctx, &types.BatchTx{
+    gk.SetOutgoingTx(ctx, &types.BatchTx{
 		BatchNonce: 1,
 		Height:     uint64(ctx.BlockHeight()),
 	})
@@ -437,12 +438,14 @@ func TestGetUnconfirmedBatchTxs(t *testing.T) {
 
 	addressA := "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 	addressB := "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-	gk.SetCompletedOutgoingTx(ctx, &types.BatchTx{
+	//gk.SetCompletedOutgoingTx(ctx, &types.BatchTx{
+	gk.SetOutgoingTx(ctx, &types.BatchTx{
 		TokenContract: addressB,
 		BatchNonce:    3,
 		Height:        blockheight,
 	})
-	gk.SetCompletedOutgoingTx(ctx, &types.BatchTx{
+	//gk.SetCompletedOutgoingTx(ctx, &types.BatchTx{
+	gk.SetOutgoingTx(ctx, &types.BatchTx{
 		TokenContract: addressA,
 		BatchNonce:    4,
 		Height:        blockheight,

--- a/module/x/gravity/keeper/contract_call.go
+++ b/module/x/gravity/keeper/contract_call.go
@@ -12,18 +12,6 @@ import (
 
 func (k Keeper) GetUnsignedContractCallTxs(ctx sdk.Context, val sdk.ValAddress) []*types.ContractCallTx {
 	var unconfirmed []*types.ContractCallTx
-	k.IterateCompletedOutgoingTxsByType(ctx, types.ContractCallTxPrefixByte, func(_ []byte, cotx types.OutgoingTx) bool {
-		sig := k.getEthereumSignature(ctx, cotx.GetStoreIndex(), val)
-		if len(sig) == 0 {
-			call, ok := cotx.(*types.ContractCallTx)
-			if !ok {
-				panic(sdkerrors.Wrapf(types.ErrInvalid, "couldn't cast to contract call for completed tx %s", cotx))
-			}
-			unconfirmed = append(unconfirmed, call)
-		}
-		return false
-	})
-
 	k.IterateOutgoingTxsByType(ctx, types.ContractCallTxPrefixByte, func(_ []byte, otx types.OutgoingTx) bool {
 		sig := k.getEthereumSignature(ctx, otx.GetStoreIndex(), val)
 		if len(sig) == 0 {

--- a/module/x/gravity/keeper/contract_call_test.go
+++ b/module/x/gravity/keeper/contract_call_test.go
@@ -96,7 +96,8 @@ func TestGetUnconfirmedContractCallTxs(t *testing.T) {
 	fees := []types.ERC20Token{}
 	sig := []byte("dummysig")
 	gk.CreateContractCallTx(ctx, 1, scope, address, payload, tokens, fees)
-	gk.SetCompletedOutgoingTx(ctx, &types.ContractCallTx{
+	//gk.SetCompletedOutgoingTx(ctx, &types.ContractCallTx{
+	gk.SetOutgoingTx(ctx, &types.ContractCallTx{
 		InvalidationNonce: 2,
 		InvalidationScope: scope,
 		Address:           address.Hex(),

--- a/module/x/gravity/keeper/grpc_query_test.go
+++ b/module/x/gravity/keeper/grpc_query_test.go
@@ -300,7 +300,9 @@ func TestKeeper_UnsignedBatchTxs(t *testing.T) {
 			res, err := gk.UnsignedBatchTxs(sdk.WrapSDKContext(ctx), req)
 			require.NoError(t, err)
 			require.NotNil(t, res)
-			require.Len(t, res.Batches, 3)
+			//require.Len(t, res.Batches, 3)
+            // Test broken by completed tx workaround to SubmitEthereumTxComfiration bug
+			require.Len(t, res.Batches, 1)
 		}
 	})
 }
@@ -344,7 +346,9 @@ func TestKeeper_UnsignedContractCallTxs(t *testing.T) {
 			res, err := gk.UnsignedContractCallTxs(sdk.WrapSDKContext(ctx), req)
 			require.NoError(t, err)
 			require.NotNil(t, res)
-			require.Len(t, res.Calls, 3)
+			//require.Len(t, res.Calls, 3)
+            // Test broken by completed tx workaround to SubmitEthereumTxComfiration bug
+			require.Len(t, res.Calls, 2)
 		}
 	})
 }

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,6 +1,6 @@
 # Reference: https://www.lpalmieri.com/posts/fast-rust-docker-builds/
 
-FROM rust:1.70 as cargo-chef-rust
+FROM rust:1.74 as cargo-chef-rust
 RUN cargo install cargo-chef --version 0.1.62
 
 FROM cargo-chef-rust as planner


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the retrieval process for unsigned batch transactions and contract call transactions, enhancing the efficiency of processing outgoing transactions.
- **Chores**
	- Updated the base Rust image version in the Dockerfile to align with the new version for cargo-chef-rust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->