### PR TITLE
Fix SubmitEthereumTxConfirmation bug

### DIFF
--- a/module/x/gravity/keeper/batch_test.go
+++ b/module/x/gravity/keeper/batch_test.go
@@ -392,8 +392,7 @@ func TestGetUnconfirmedBatchTxs(t *testing.T) {
 
 	blockheight := uint64(ctx.BlockHeight())
 	sig := []byte("dummysig")
-	//gk.SetCompletedOutgoingTx(ctx, &types.BatchTx{
-    gk.SetOutgoingTx(ctx, &types.BatchTx{
+	gk.SetCompletedOutgoingTx(ctx, &types.BatchTx{
 		BatchNonce: 1,
 		Height:     uint64(ctx.BlockHeight()),
 	})
@@ -438,14 +437,12 @@ func TestGetUnconfirmedBatchTxs(t *testing.T) {
 
 	addressA := "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 	addressB := "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-	//gk.SetCompletedOutgoingTx(ctx, &types.BatchTx{
-	gk.SetOutgoingTx(ctx, &types.BatchTx{
+	gk.SetCompletedOutgoingTx(ctx, &types.BatchTx{
 		TokenContract: addressB,
 		BatchNonce:    3,
 		Height:        blockheight,
 	})
-	//gk.SetCompletedOutgoingTx(ctx, &types.BatchTx{
-	gk.SetOutgoingTx(ctx, &types.BatchTx{
+	gk.SetCompletedOutgoingTx(ctx, &types.BatchTx{
 		TokenContract: addressA,
 		BatchNonce:    4,
 		Height:        blockheight,

--- a/module/x/gravity/keeper/contract_call_test.go
+++ b/module/x/gravity/keeper/contract_call_test.go
@@ -96,8 +96,7 @@ func TestGetUnconfirmedContractCallTxs(t *testing.T) {
 	fees := []types.ERC20Token{}
 	sig := []byte("dummysig")
 	gk.CreateContractCallTx(ctx, 1, scope, address, payload, tokens, fees)
-	//gk.SetCompletedOutgoingTx(ctx, &types.ContractCallTx{
-	gk.SetOutgoingTx(ctx, &types.ContractCallTx{
+	gk.SetCompletedOutgoingTx(ctx, &types.ContractCallTx{
 		InvalidationNonce: 2,
 		InvalidationScope: scope,
 		Address:           address.Hex(),

--- a/module/x/gravity/keeper/grpc_query_test.go
+++ b/module/x/gravity/keeper/grpc_query_test.go
@@ -300,9 +300,7 @@ func TestKeeper_UnsignedBatchTxs(t *testing.T) {
 			res, err := gk.UnsignedBatchTxs(sdk.WrapSDKContext(ctx), req)
 			require.NoError(t, err)
 			require.NotNil(t, res)
-			//require.Len(t, res.Batches, 3)
-            // Test broken by completed tx workaround to SubmitEthereumTxComfiration bug
-			require.Len(t, res.Batches, 1)
+			require.Len(t, res.Batches, 3)
 		}
 	})
 }
@@ -346,9 +344,7 @@ func TestKeeper_UnsignedContractCallTxs(t *testing.T) {
 			res, err := gk.UnsignedContractCallTxs(sdk.WrapSDKContext(ctx), req)
 			require.NoError(t, err)
 			require.NotNil(t, res)
-			//require.Len(t, res.Calls, 3)
-            // Test broken by completed tx workaround to SubmitEthereumTxComfiration bug
-			require.Len(t, res.Calls, 2)
+			require.Len(t, res.Calls, 3)
 		}
 	})
 }

--- a/module/x/gravity/keeper/msg_server.go
+++ b/module/x/gravity/keeper/msg_server.go
@@ -117,13 +117,16 @@ func (k msgServer) SubmitEthereumTxConfirmation(c context.Context, msg *types.Ms
 		return nil, err
 	}
 
-	otx := k.GetOutgoingTx(ctx, confirmation.GetStoreIndex())
-	if otx == nil {
-		k.Logger(ctx).Error(
-			"no outgoing tx",
-			"store index", fmt.Sprintf("%x", confirmation.GetStoreIndex()),
-		)
-		return nil, sdkerrors.Wrap(types.ErrInvalid, "couldn't find outgoing tx")
+	var otx types.OutgoingTx
+	if otx = k.GetOutgoingTx(ctx, confirmation.GetStoreIndex()); otx == nil {
+		if otx = k.GetCompletedOutgoingTx(ctx, confirmation.GetStoreIndex()); otx == nil {
+			k.Logger(ctx).Error(
+				"no outgoing tx",
+				"store index", fmt.Sprintf("%x", confirmation.GetStoreIndex()),
+			)
+
+			return nil, sdkerrors.Wrap(types.ErrInvalid, "couldn't find outgoing tx")
+		}
 	}
 
 	gravityID := k.getGravityID(ctx)


### PR DESCRIPTION
Adds an additional lookup to check if the signature is targeting an already-completed outgoing tx. 

I verified manually that this fixes the issue with the following steps:

1. Start the happy path test
2. Turn off orchestrator 3 as soon as it is started
3. Stop the test after the SendToEthereum is submitted
4. Watch another orchestrator's log until the batch is submitted
5. Query signatures to confirm there are 3
6. Turn orchestrator 3 back on
7. Observe 4th signature submission

Closes #555