### PR TITLE
chore: make function comment match function name

### DIFF
--- a/module/x/gravity/abci_test.go
+++ b/module/x/gravity/abci_test.go
@@ -199,7 +199,7 @@ func TestSignerSetTxSlashing_UnbondingValidator_UnbondWindow_NotExpired(t *testi
 	// check if tokens shouldn't be slashed for val2.
 }
 
-// TestBatchAndContractCallSlashingAndPruning tests that slashing and pruning are working properly for the
+// TestTxSlashingAndPruning tests that slashing and pruning are working properly for the
 // batch and contract call implementations of OutgoingTx. It also implicitly tests that two slashes against
 // a validator do not result in a second jail call, which would cause panic and chain halt.
 func TestTxSlashingAndPruning(t *testing.T) {

--- a/module/x/gravity/keeper/slashing.go
+++ b/module/x/gravity/keeper/slashing.go
@@ -53,7 +53,7 @@ func (k Keeper) GetBondedValidatorSlashingInfos(ctx sdk.Context) ([]stakingtypes
 	return bondedValidators, bondedValInfos
 }
 
-// GetValidatorInfo returns the consensus key address, signing info, and whether or not the validator exists, for the purposes of slashing/jailing
+// GetValidatorSlashingInfo returns the consensus key address, signing info, and whether or not the validator exists, for the purposes of slashing/jailing
 func (k Keeper) GetValidatorSlashingInfo(ctx sdk.Context, validator stakingtypes.Validator) ValidatorSlashingInfo {
 	consensusKeyAddress, err := validator.GetConsAddr()
 	if err != nil {


### PR DESCRIPTION
make function comment match function name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated internal comment descriptions to enhance clarity and consistency in describing slashing and pruning mechanisms.
  - Revised naming conventions to better reflect underlying functionality without altering user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->