### PR TITLE
feat: SignerType impl of ethers::signers::Signer in place of hardcoded LocalWallet

### DIFF
--- a/integration_tests/happy_path_test.go
+++ b/integration_tests/happy_path_test.go
@@ -251,7 +251,7 @@ func (s *IntegrationTestSuite) TestHappyPath() {
 			s.Require().Equal(uint64(1), proposalsQueryResponse.Proposals[0].ProposalId, "not proposal id 1")
 			s.Require().Equal(govtypesv1beta1.StatusVotingPeriod, proposalsQueryResponse.Proposals[0].Status, "proposal not in voting period")
 			return true
-		}, 20*time.Second, 2*time.Second, "proposal not submitted correctly")
+		}, 60*time.Second, 2*time.Second, "proposal not submitted correctly")
 
 		s.T().Log("vote for community spend proposal")
 		for _, val := range s.chain.validators {

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -276,6 +276,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +367,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a194f9d963d8099596278594b3107448656ba73831c9d8c783e613ce86da64"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -487,12 +515,40 @@ dependencies = [
 
 [[package]]
 name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.3.4",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 0.1.2",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -506,8 +562,25 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "mime",
+ "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -527,7 +600,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -573,9 +646,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.0.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bech32"
@@ -875,7 +948,11 @@ version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
  "num-traits",
+ "serde",
+ "windows-link",
 ]
 
 [[package]]
@@ -1120,9 +1197,9 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "462e1f6a8e005acc8835d32d60cbd7973ed65ea2a8d8473830e675f050956427"
 dependencies = [
- "prost",
+ "prost 0.13.5",
  "tendermint-proto",
- "tonic",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -1131,9 +1208,9 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcff930b3949e2bc81a2529af55d05bb8cf624ee34c36e6eaf6262cb9983a5d"
 dependencies = [
- "prost",
- "prost-types",
- "tonic",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -1269,8 +1346,8 @@ dependencies = [
  "num-traits",
  "num256 0.6.0",
  "pbkdf2 0.12.2",
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "rand 0.8.5",
  "ripemd",
  "rust_decimal",
@@ -1280,7 +1357,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "tokio",
- "tonic",
+ "tonic 0.12.3",
  "unicode-normalization",
 ]
 
@@ -1300,6 +1377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -1679,7 +1757,7 @@ dependencies = [
  "ethers-providers",
  "futures-util",
  "once_cell",
- "pin-project",
+ "pin-project 1.1.3",
  "serde",
  "serde_json",
  "thiserror 1.0.50",
@@ -1772,6 +1850,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-gcp-kms-signer"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31feeb979fc5893e55742d43dd9429928e0601f0a1b466abd6849e7b7e60a744"
+dependencies = [
+ "async-trait",
+ "ethers",
+ "gcloud-sdk",
+ "spki 0.7.3",
+ "thiserror 1.0.50",
+ "tonic 0.9.2",
+ "tracing",
+]
+
+[[package]]
 name = "ethers-middleware"
 version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,7 +1912,7 @@ dependencies = [
  "instant",
  "jsonwebtoken",
  "once_cell",
- "pin-project",
+ "pin-project 1.1.3",
  "reqwest",
  "serde",
  "serde_json",
@@ -2142,6 +2235,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcemeta"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d460327b24cc34c86d53d60a90e9e6044817f7906ebd9baa5c3d0ee13e1ecf"
+dependencies = [
+ "bytes",
+ "hyper 0.14.27",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.50",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "gcloud-sdk"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a24376e7850e7864bb326debc5765a1dda4fc47603c22e2bc0ebf30ff59141b"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "gcemeta",
+ "hyper 0.14.27",
+ "jsonwebtoken",
+ "once_cell",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "reqwest",
+ "secret-vault-value",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic 0.9.2",
+ "tower",
+ "tower-layer",
+ "tower-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,7 +2342,7 @@ dependencies = [
  "openssl-probe",
  "orchestrator",
  "pkcs8 0.7.6",
- "prost",
+ "prost 0.13.5",
  "rand_core 0.6.4",
  "regex",
  "relayer",
@@ -2223,6 +2359,7 @@ name = "gravity"
 version = "5.0.0"
 dependencies = [
  "actix",
+ "async-trait",
  "bytes",
  "clarity 1.5.1",
  "cosmos-sdk-proto",
@@ -2230,21 +2367,22 @@ dependencies = [
  "deep_space",
  "env_logger",
  "ethers",
+ "ethers-gcp-kms-signer",
  "gravity_abi",
  "gravity_proto",
  "lazy_static",
  "log",
  "num-bigint 0.4.4",
  "num256 0.6.0",
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "rand 0.8.5",
  "regex",
  "rustc-hex",
  "serde",
  "sha3 0.9.1",
  "tokio",
- "tonic",
+ "tonic 0.12.3",
  "url",
 ]
 
@@ -2287,20 +2425,20 @@ dependencies = [
  "bytes",
  "cosmos-sdk-proto",
  "cosmos-sdk-proto-althea",
- "prost",
- "prost-types",
- "tonic",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "tonic 0.12.3",
 ]
 
 [[package]]
 name = "gravity_proto_build"
 version = "0.1.0"
 dependencies = [
- "prost",
+ "prost 0.13.5",
  "prost-build",
  "regex",
  "tempdir",
- "tonic",
+ "tonic 0.12.3",
  "tonic-build",
  "walkdir",
 ]
@@ -2602,6 +2740,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper 0.14.27",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
@@ -2630,6 +2780,29 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2747,6 +2920,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2973,6 +3155,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -3343,7 +3535,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tokio",
- "tonic",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -3499,9 +3691,18 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e93a3b1cc0510b03020f33f21e62acdde3dcaef432edc95bea377fbd4c2cd4"
+checksum = "8f22eb0e3c593294a99e9ff4b24cf6b752d43f193aa4415fe5077c159996d497"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
@@ -3586,11 +3787,31 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
+dependencies = [
+ "pin-project-internal 0.4.30",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.1.3",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3623,7 +3844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
 dependencies = [
  "der 0.4.5",
- "pem-rfc7468",
+ "pem-rfc7468 0.2.3",
  "spki 0.4.1",
  "zeroize",
 ]
@@ -3737,12 +3958,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -3758,11 +3989,24 @@ dependencies = [
  "once_cell",
  "petgraph 0.7.1",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "regex",
  "syn 2.0.100",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3780,11 +4024,20 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost",
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -4036,7 +4289,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "tokio",
- "tonic",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -4063,6 +4316,7 @@ version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
+ "async-compression",
  "base64 0.21.5",
  "bytes",
  "encoding_rs",
@@ -4077,6 +4331,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4088,10 +4343,12 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
+ "tokio-util 0.7.10",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -4295,6 +4552,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.3",
+ "schannel",
+ "security-framework 2.10.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
@@ -4302,7 +4571,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -4507,6 +4776,32 @@ checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "secret-vault-value"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc32a777b53b3433b974c9c26b6d502a50037f8da94e46cb8ce2ced2cfdfaea0"
+dependencies = [
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "serde",
+ "serde_json",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.3",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -4948,6 +5243,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -5022,7 +5323,7 @@ checksum = "9ae9e1705aa0fa5ecb2c6aa7fb78c2313c4a31158ea5f02048bf318f849352eb"
 dependencies = [
  "bytes",
  "flex-error",
- "prost",
+ "prost 0.13.5",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -5067,7 +5368,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "tokio",
- "tonic",
+ "tonic 0.12.3",
  "url",
 ]
 
@@ -5192,6 +5493,16 @@ dependencies = [
  "socket2 0.5.5",
  "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -5336,6 +5647,38 @@ dependencies = [
 
 [[package]]
 name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.6.20",
+ "base64 0.21.5",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.21",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
+ "hyper-timeout 0.4.1",
+ "percent-encoding",
+ "pin-project 1.1.3",
+ "prost 0.11.9",
+ "rustls-native-certs 0.6.3",
+ "rustls-pemfile 1.0.3",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
@@ -5351,12 +5694,12 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-timeout",
+ "hyper-timeout 0.5.2",
  "hyper-util",
  "percent-encoding",
- "pin-project",
- "prost",
- "rustls-native-certs",
+ "pin-project 1.1.3",
+ "prost 0.13.5",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "socket2 0.5.5",
  "tokio",
@@ -5377,7 +5720,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
- "prost-types",
+ "prost-types 0.13.5",
  "quote",
  "syn 2.0.100",
 ]
@@ -5391,7 +5734,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap 1.9.3",
- "pin-project",
+ "pin-project 1.1.3",
  "pin-project-lite",
  "rand 0.8.5",
  "slab",
@@ -5413,7 +5756,7 @@ dependencies = [
  "futures-util",
  "http 0.2.9",
  "http-body 0.4.5",
- "pin-project",
+ "pin-project 1.1.3",
  "tower-layer",
  "tower-service",
 ]
@@ -5429,6 +5772,18 @@ name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tower-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project 0.4.30",
+ "tower-service",
+]
 
 [[package]]
 name = "tracing"
@@ -5469,7 +5824,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project",
+ "pin-project 1.1.3",
  "tracing",
 ]
 
@@ -5574,6 +5929,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"
@@ -5772,6 +6133,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5836,6 +6210,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-sys"

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,6 +1,6 @@
 # Reference: https://www.lpalmieri.com/posts/fast-rust-docker-builds/
 
-FROM rust:1.79-bullseye AS cargo-chef-rust
+FROM rust:1.81-bullseye AS cargo-chef-rust
 RUN cargo install cargo-chef --version 0.1.62 --locked
 
 FROM cargo-chef-rust AS planner

--- a/orchestrator/gorc/src/config.rs
+++ b/orchestrator/gorc/src/config.rs
@@ -1,6 +1,7 @@
 use ethers::signers::LocalWallet;
 use gravity::deep_space::private_key::DEFAULT_COSMOS_HD_PATH;
 use gravity::deep_space::CosmosPrivateKey;
+use gravity::ethereum::types::SignerType;
 use serde::{Deserialize, Serialize};
 use signatory::FsKeyStore;
 use std::net::SocketAddr;
@@ -30,12 +31,12 @@ impl GorcConfig {
         clarity::PrivateKey::from_bytes(key.into()).expect("Could not convert key")
     }
 
-    pub fn load_ethers_wallet(&self, name: String) -> LocalWallet {
+    pub fn load_ethers_wallet(&self, name: String) -> SignerType {
         let secret_key = self.load_secret_key(name);
         let bytes = secret_key.to_bytes();
         let ethers_secret = ethers::core::k256::SecretKey::from_bytes(&bytes).unwrap();
         let signing_key = ethers::core::k256::ecdsa::SigningKey::from(ethers_secret);
-        LocalWallet::from(signing_key)
+        SignerType::Local(LocalWallet::from(signing_key))
     }
 
     pub fn load_deep_space_key(&self, name: String) -> CosmosPrivateKey {

--- a/orchestrator/gravity/Cargo.toml
+++ b/orchestrator/gravity/Cargo.toml
@@ -7,12 +7,14 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.88"
 bytes = { workspace = true }
 clarity = { workspace = true }
 cosmos-sdk-proto = { workspace = true }
 cosmos-sdk-proto-althea = { workspace = true }
 deep_space = "2.27.4"
 ethers = { workspace = true }
+ethers-gcp-kms-signer = "0.1.5"
 gravity_abi = { path = "../gravity_abi" }
 gravity_proto = {path = "../gravity_proto/"}
 lazy_static = "1.4.0"

--- a/orchestrator/gravity/src/ethereum/types.rs
+++ b/orchestrator/gravity/src/ethereum/types.rs
@@ -1,5 +1,87 @@
-use ethers::prelude::*;
+use ethers::{
+    prelude::*,
+    types::transaction::{eip2718::TypedTransaction, eip712::Eip712},
+};
+use ethers_gcp_kms_signer::GcpKmsSigner;
 use std::sync::Arc;
 
-pub type EthSignerMiddleware = SignerMiddleware<Provider<Http>, LocalWallet>;
+pub type EthSignerMiddleware = SignerMiddleware<Provider<Http>, SignerType>;
 pub type EthClient = Arc<EthSignerMiddleware>;
+
+/// Wrapper enum for different signer types
+#[derive(Clone, Debug)]
+pub enum SignerType {
+    Local(LocalWallet),
+    GcpKms(GcpKmsSigner),
+}
+
+#[async_trait::async_trait]
+impl Signer for SignerType {
+    type Error = ethers::providers::ProviderError;
+
+    async fn sign_message<S: Send + Sync + AsRef<[u8]>>(
+        &self,
+        message: S,
+    ) -> Result<Signature, Self::Error> {
+        match self {
+            SignerType::Local(wallet) => wallet
+                .sign_message(message)
+                .await
+                .map_err(|e| ethers::providers::ProviderError::CustomError(e.to_string())),
+            SignerType::GcpKms(signer) => signer
+                .sign_message(message)
+                .await
+                .map_err(|e| ethers::providers::ProviderError::CustomError(e.to_string())),
+        }
+    }
+
+    async fn sign_transaction(&self, tx: &TypedTransaction) -> Result<Signature, Self::Error> {
+        match self {
+            SignerType::Local(wallet) => wallet
+                .sign_transaction(tx)
+                .await
+                .map_err(|e| ethers::providers::ProviderError::CustomError(e.to_string())),
+            SignerType::GcpKms(signer) => signer
+                .sign_transaction(tx)
+                .await
+                .map_err(|e| ethers::providers::ProviderError::CustomError(e.to_string())),
+        }
+    }
+
+    fn address(&self) -> Address {
+        match self {
+            SignerType::Local(wallet) => wallet.address(),
+            SignerType::GcpKms(signer) => signer.address(),
+        }
+    }
+
+    fn chain_id(&self) -> u64 {
+        match self {
+            SignerType::Local(wallet) => wallet.chain_id(),
+            SignerType::GcpKms(signer) => signer.chain_id(),
+        }
+    }
+
+    fn with_chain_id<T: Into<u64>>(self, chain_id: T) -> Self {
+        match self {
+            SignerType::Local(wallet) => SignerType::Local(wallet.with_chain_id(chain_id)),
+            SignerType::GcpKms(signer) => SignerType::GcpKms(signer.with_chain_id(chain_id)),
+        }
+    }
+
+    async fn sign_typed_data<T: Eip712 + Send + Sync>(
+        &self,
+        payload: &T,
+    ) -> Result<Signature, Self::Error> {
+        match self {
+            SignerType::Local(wallet) => wallet
+                .sign_typed_data(payload)
+                .await
+                .map_err(|e| ethers::providers::ProviderError::CustomError(e.to_string())),
+            SignerType::GcpKms(signer) => signer
+                .sign_typed_data(payload)
+                .await
+                .map_err(|e| ethers::providers::ProviderError::CustomError(e.to_string())),
+        }
+    }
+}

--- a/orchestrator/gravity/src/utils/connection_prep.rs
+++ b/orchestrator/gravity/src/utils/connection_prep.rs
@@ -2,6 +2,7 @@
 //! It's a common problem to have conflicts between ipv4 and ipv6 localhost and this module is first and foremost supposed to resolve that problem
 //! by trying more than one thing to handle potentially misconfigured inputs.
 
+use crate::ethereum::types::SignerType;
 use crate::utils::ethereum::format_eth_address;
 use deep_space::client::ChainStatus;
 use deep_space::Address as CosmosAddress;
@@ -356,7 +357,7 @@ pub async fn check_for_fee_denom(fee_denom: &str, address: CosmosAddress, contac
 /// Checks the user has some Ethereum in their address to pay for things
 pub async fn check_for_eth(
     address: EthAddress,
-    eth_client: Arc<SignerMiddleware<Provider<Http>, LocalWallet>>,
+    eth_client: Arc<SignerMiddleware<Provider<Http>, SignerType>>,
 ) {
     let balance = eth_client.get_balance(address, None).await.unwrap();
     if balance == 0u8.into() {

--- a/orchestrator/gravity/src/utils/error.rs
+++ b/orchestrator/gravity/src/utils/error.rs
@@ -1,5 +1,6 @@
 //! for things that don't belong in the cosmos or ethereum libraries but also don't belong
 //! in a function specific library
+use crate::ethereum::types::SignerType;
 use clarity::Error as ClarityError;
 use deep_space::error::AddressError as CosmosAddressError;
 use deep_space::error::CosmosGrpcError;
@@ -30,10 +31,10 @@ pub enum GravityError {
     CosmosAddressError(CosmosAddressError),
     CosmosPrivateKeyError(CosmosPrivateKeyError),
     EthereumBadDataError(String),
-    EthereumRestError(SignerMiddlewareError<Provider<Http>, LocalWallet>),
+    EthereumRestError(SignerMiddlewareError<Provider<Http>, SignerType>),
     EthersAbiError(EthersAbiError),
     EthersContractAbiError(EthersContractAbiError),
-    EthersContractError(ContractError<SignerMiddleware<Provider<Http>, LocalWallet>>),
+    EthersContractError(ContractError<SignerMiddleware<Provider<Http>, SignerType>>),
     EthersGasOracleError(EthersGasOracleError),
     EthersParseAddressError(EthersParseAddressError),
     EthersParseUintError(EthersParseUintError),
@@ -149,8 +150,8 @@ impl From<ClarityError> for GravityError {
     }
 }
 
-impl From<SignerMiddlewareError<Provider<Http>, LocalWallet>> for GravityError {
-    fn from(error: SignerMiddlewareError<Provider<Http>, LocalWallet>) -> Self {
+impl From<SignerMiddlewareError<Provider<Http>, SignerType>> for GravityError {
+    fn from(error: SignerMiddlewareError<Provider<Http>, SignerType>) -> Self {
         GravityError::EthereumRestError(error)
     }
 }
@@ -167,8 +168,8 @@ impl From<EthersContractAbiError> for GravityError {
     }
 }
 
-impl From<ContractError<SignerMiddleware<Provider<Http>, LocalWallet>>> for GravityError {
-    fn from(error: ContractError<SignerMiddleware<Provider<Http>, LocalWallet>>) -> Self {
+impl From<ContractError<SignerMiddleware<Provider<Http>, SignerType>>> for GravityError {
+    fn from(error: ContractError<SignerMiddleware<Provider<Http>, SignerType>>) -> Self {
         GravityError::EthersContractError(error)
     }
 }

--- a/orchestrator/relayer/src/main.rs
+++ b/orchestrator/relayer/src/main.rs
@@ -7,6 +7,7 @@ use env_logger::Env;
 use ethers::prelude::*;
 use ethers::signers::LocalWallet as EthWallet;
 use ethers::types::Address as EthAddress;
+use gravity::ethereum::types::SignerType;
 use gravity::utils::connection_prep::check_for_eth;
 use gravity::utils::connection_prep::create_rpc_connections;
 use gravity::utils::connection_prep::wait_for_cosmos_node_ready;
@@ -73,6 +74,7 @@ async fn main() {
         .flag_ethereum_key
         .parse()
         .expect("Invalid Ethereum private key!");
+    let ethereum_wallet = SignerType::Local(ethereum_wallet);
     let gravity_contract_address: EthAddress = args
         .flag_contract_address
         .parse()

--- a/orchestrator/test_runner/src/happy_path_v2.rs
+++ b/orchestrator/test_runner/src/happy_path_v2.rs
@@ -10,6 +10,7 @@ use ethers::types::Address as EthAddress;
 use gravity::deep_space::coin::Coin;
 use gravity::deep_space::Contact;
 use gravity::ethereum::erc20_utils::get_erc20_balance;
+use gravity::ethereum::types::SignerType;
 use gravity::ethereum::{deploy_erc20::deploy_erc20, utils::get_event_nonce};
 use gravity::send::send_to_eth;
 use gravity::utils::ethereum::downcast_to_u64;
@@ -28,7 +29,7 @@ pub async fn happy_path_test_v2(
     gravity_address: EthAddress,
 ) {
     let mut grpc_client = grpc_client;
-    let eth_wallet = LocalWallet::from(keys[0].eth_key.clone());
+    let eth_wallet = SignerType::Local(LocalWallet::from(keys[0].eth_key.clone()));
     let provider = eth_provider.clone();
     let chain_id = provider
         .get_chainid()

--- a/orchestrator/test_runner/src/main.rs
+++ b/orchestrator/test_runner/src/main.rs
@@ -21,6 +21,7 @@ use gravity::deep_space::coin::Coin;
 use gravity::deep_space::Contact;
 use gravity::deep_space::PrivateKey;
 use gravity::ethereum::types::EthClient;
+use gravity::ethereum::types::SignerType;
 use gravity::utils::ethereum::hex_str_to_bytes;
 use gravity::utils::wait_for_cosmos_online;
 use gravity_proto::gravity::query_client::QueryClient as GravityQueryClient;
@@ -70,10 +71,10 @@ lazy_static! {
         SigningKey::from_bytes(GenericArray::from_slice(hex_str_to_bytes(
             "0xb1bab011e03a9862664706fc3bbaa1b16651528e5f0e7fbfcbfdd8be302a13e7").unwrap().as_slice()
         )).unwrap();
-    static ref MINER_WALLET: LocalWallet = LocalWallet::from((*MINER_PRIVATE_KEY).clone());
+    static ref MINER_WALLET: SignerType = SignerType::Local(LocalWallet::from((*MINER_PRIVATE_KEY).clone()));
     static ref MINER_ADDRESS: EthAddress = (*MINER_WALLET).address();
     static ref MINER_PROVIDER: Provider<Http> = Provider::<Http>::try_from((*ETH_NODE).clone()).unwrap();
-    static ref MINER_SIGNER: SignerMiddleware<Provider<Http>, LocalWallet> =
+    static ref MINER_SIGNER: SignerMiddleware<Provider<Http>, SignerType> =
         SignerMiddleware::new((*MINER_PROVIDER).clone(), (*MINER_WALLET).clone());
     static ref MINER_CLIENT: EthClient = Arc::new((*MINER_SIGNER).clone());
 

--- a/orchestrator/test_runner/src/transaction_stress_test.rs
+++ b/orchestrator/test_runner/src/transaction_stress_test.rs
@@ -5,13 +5,13 @@ use clarity::Uint256;
 use ethers::prelude::*;
 use ethers::types::Address as EthAddress;
 use futures::future::join_all;
-use gravity::deep_space::coin::Coin;
 use gravity::deep_space::Contact;
 use gravity::ethereum::erc20_utils::get_erc20_balance;
 use gravity::ethereum::send_to_cosmos::send_to_cosmos;
 use gravity::ethereum::utils::get_tx_batch_nonce;
 use gravity::send::send_to_eth;
 use gravity::utils::ethereum::downcast_to_u64;
+use gravity::{deep_space::coin::Coin, ethereum::types::SignerType};
 use std::{collections::HashSet, str::FromStr, sync::Arc, time::Duration};
 
 const TIMEOUT: Duration = Duration::from_secs(120);
@@ -67,7 +67,7 @@ pub async fn transaction_stress_test(
     for token in erc20_addresses.iter() {
         let mut sends = Vec::new();
         for keys in user_keys.iter() {
-            let eth_wallet = LocalWallet::from(keys.eth_key.clone());
+            let eth_wallet = SignerType::Local(LocalWallet::from(keys.eth_key.clone()));
             let provider = eth_provider.clone();
             let chain_id = provider
                 .get_chainid()
@@ -228,7 +228,7 @@ pub async fn transaction_stress_test(
 
     // we should find a batch nonce greater than zero since all the batches
     // executed
-    let eth_wallet = LocalWallet::from(keys[0].eth_key.clone());
+    let eth_wallet = SignerType::Local(LocalWallet::from(keys[0].eth_key.clone()));
     let eth_client = Arc::new(SignerMiddleware::new(eth_provider.clone(), eth_wallet));
     for token in erc20_addresses {
         assert!(


### PR DESCRIPTION
- Adds an enum `SignerType` that currently supports `LocalWallet` and `GcpKmsSigner`
- Updates all `SignerMiddleware` construction with a `LocalWallet` to wrap it in a `SignerType`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Upgraded the underlying Rust environment to a newer version, enhancing build reliability and stability.
- **Refactor**
	- Improved Ethereum wallet operations by adopting a unified signing mechanism that supports multiple signing methods, resulting in streamlined wallet management and more consistent error handling.
- **Tests**
	- Increased timeout duration for assertions in integration tests to allow for longer wait times for conditions to be satisfied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->