### PR TITLE
Mofify signatures with an invalid v inflight

### DIFF
--- a/orchestrator/gravity/src/query.rs
+++ b/orchestrator/gravity/src/query.rs
@@ -74,9 +74,12 @@ pub async fn get_all_valset_confirms(
             match e {
                 clarity::Error::InvalidV => {
                     let mut corrected_sig = item.signature.clone();
-                    corrected_sig[64] = 28;
+                    corrected_sig[64] += 27;
                     let mut corrected = item.clone();
                     corrected.signature = corrected_sig;
+                    Signature::from_bytes(&corrected.signature)?
+                        .error_check()
+                        .unwrap();
                     debug!("Corrected the V value on signature");
                     parsed_confirms.push(ValsetConfirmResponse::from_proto(corrected)?);
                     continue;
@@ -164,9 +167,12 @@ pub async fn get_transaction_batch_signatures(
             match e {
                 clarity::Error::InvalidV => {
                     let mut corrected_sig = confirm.signature.clone();
-                    corrected_sig[64] = 28;
+                    corrected_sig[64] += 27;
                     let mut corrected = confirm.clone();
                     corrected.signature = corrected_sig;
+                    Signature::from_bytes(&corrected.signature)?
+                        .error_check()
+                        .unwrap();
                     debug!("Corrected the V value on signature");
                     out.push(BatchConfirmResponse::from_proto(corrected)?);
                     continue;
@@ -241,9 +247,12 @@ pub async fn get_logic_call_signatures(
             match e {
                 clarity::Error::InvalidV => {
                     let mut corrected_sig = confirm.signature.clone();
-                    corrected_sig[64] = 28;
+                    corrected_sig[64] += 27;
                     let mut corrected = confirm.clone();
                     corrected.signature = corrected_sig;
+                    Signature::from_bytes(&corrected.signature)?
+                        .error_check()
+                        .unwrap();
                     debug!("Corrected the V value on signature");
                     out.push(LogicCallConfirmResponse::from_proto(corrected)?);
                     continue;

--- a/orchestrator/gravity/src/query.rs
+++ b/orchestrator/gravity/src/query.rs
@@ -71,8 +71,20 @@ pub async fn get_all_valset_confirms(
                 item.ethereum_signer
             );
             debug!("reason given for invalid signature: {e:?}");
-
-            continue;
+            match e {
+                clarity::Error::InvalidV => {
+                    let mut corrected_sig = item.signature.clone();
+                    corrected_sig[64] = 28;
+                    let mut corrected = item.clone();
+                    corrected.signature = corrected_sig;
+                    parsed_confirms.push(ValsetConfirmResponse::from_proto(corrected)?);
+                    continue;
+                    //Do not skip the signature if the V value is invalid.
+                }
+                _ => {
+                    continue;
+                }
+            }
         }
 
         parsed_confirms.push(ValsetConfirmResponse::from_proto(item)?)

--- a/orchestrator/gravity/src/query.rs
+++ b/orchestrator/gravity/src/query.rs
@@ -77,6 +77,7 @@ pub async fn get_all_valset_confirms(
                     corrected_sig[64] = 28;
                     let mut corrected = item.clone();
                     corrected.signature = corrected_sig;
+                    debug!("Corrected the V value on signature");
                     parsed_confirms.push(ValsetConfirmResponse::from_proto(corrected)?);
                     continue;
                     //Do not skip the signature if the V value is invalid.
@@ -160,7 +161,21 @@ pub async fn get_transaction_batch_signatures(
             );
             debug!("reason given for invalid signature: {e:?}");
 
-            continue;
+            match e {
+                clarity::Error::InvalidV => {
+                    let mut corrected_sig = confirm.signature.clone();
+                    corrected_sig[64] = 28;
+                    let mut corrected = confirm.clone();
+                    corrected.signature = corrected_sig;
+                    debug!("Corrected the V value on signature");
+                    out.push(BatchConfirmResponse::from_proto(corrected)?);
+                    continue;
+                    //Do not skip the signature if the V value is invalid.
+                }
+                _ => {
+                    continue;
+                }
+            }
         }
 
         out.push(BatchConfirmResponse::from_proto(confirm)?)
@@ -223,9 +238,21 @@ pub async fn get_logic_call_signatures(
                 "ignoring logic call confirmation with invalid signature from {}",
                 confirm.ethereum_signer
             );
-            debug!("reason given for invalid signature: {e:?}");
-
-            continue;
+            match e {
+                clarity::Error::InvalidV => {
+                    let mut corrected_sig = confirm.signature.clone();
+                    corrected_sig[64] = 28;
+                    let mut corrected = confirm.clone();
+                    corrected.signature = corrected_sig;
+                    debug!("Corrected the V value on signature");
+                    out.push(LogicCallConfirmResponse::from_proto(corrected)?);
+                    continue;
+                    //Do not skip the signature if the V value is invalid.
+                }
+                _ => {
+                    continue;
+                }
+            }
         }
 
         out.push(LogicCallConfirmResponse::from_proto(confirm)?)


### PR DESCRIPTION
This doesn't check the signature recovery after modification. It might be necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of specific signature errors when processing confirmations, allowing more valid confirmations to be accepted instead of skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->