### PR TITLE
Harden ERC20 deploy event mapping

### DIFF
--- a/module/x/gravity/keeper/ethereum_event_handler.go
+++ b/module/x/gravity/keeper/ethereum_event_handler.go
@@ -91,6 +91,21 @@ func (k Keeper) verifyERC20DeployedEvent(ctx sdk.Context, event *types.ERC20Depl
 		)
 	}
 
+	if _, err := types.GravityDenomToERC20(event.CosmosDenom); err == nil {
+		return errors.Wrapf(
+			types.ErrInvalidERC20Event,
+			"cannot deploy ethereum-originated voucher denom %s as a Cosmos-originated ERC20", event.CosmosDenom,
+		)
+	}
+
+	tokenContract := common.HexToAddress(event.TokenContract)
+	if existingDenom, exists := k.getCosmosOriginatedDenom(ctx, tokenContract); exists {
+		return errors.Wrapf(
+			types.ErrInvalidERC20Event,
+			"ERC20 denom %s already exists for token contract %s", existingDenom, tokenContract.Hex(),
+		)
+	}
+
 	// We expect that all Cosmos-based tokens have metadata defined. In the case
 	// a token does not have metadata defined, e.g. an IBC token, we successfully
 	// handle the token under the following conditions:

--- a/module/x/gravity/keeper/ethereum_event_handler_test.go
+++ b/module/x/gravity/keeper/ethereum_event_handler_test.go
@@ -5,7 +5,11 @@ import (
 	"testing"
 
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+
+	"github.com/peggyjv/gravity-bridge/module/v6/x/gravity/types"
 )
 
 func TestDetectMaliciousSupply(t *testing.T) {
@@ -18,4 +22,72 @@ func TestDetectMaliciousSupply(t *testing.T) {
 
 	err := input.GravityKeeper.DetectMaliciousSupply(input.Context, "stake", bigCoinAmount)
 	require.Error(t, err, "didn't error out on too much added supply")
+}
+
+func TestERC20DeployedEventRejectsExistingTokenContractMapping(t *testing.T) {
+	input := CreateTestEnv(t)
+	ctx := input.Context
+	existingContract := common.HexToAddress("0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e")
+
+	input.GravityKeeper.setCosmosOriginatedDenomToERC20(ctx, "uatom", existingContract)
+	input.BankKeeper.SetDenomMetaData(ctx, banktypes.Metadata{
+		DenomUnits: []*banktypes.DenomUnit{
+			{Denom: "uosmo", Exponent: 0},
+			{Denom: "osmo", Exponent: 6},
+		},
+		Base:    "uosmo",
+		Display: "osmo",
+	})
+
+	err := input.GravityKeeper.Handle(ctx, &types.ERC20DeployedEvent{
+		CosmosDenom:   "uosmo",
+		TokenContract: existingContract.Hex(),
+		Erc20Name:     "osmo",
+		Erc20Symbol:   "osmo",
+		Erc20Decimals: 6,
+		EventNonce:    1,
+	})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, types.ErrInvalidERC20Event)
+	require.Contains(t, err.Error(), "already exists for token contract")
+
+	isCosmosOriginated, denom := input.GravityKeeper.ERC20ToDenomLookup(ctx, existingContract)
+	require.True(t, isCosmosOriginated)
+	require.Equal(t, "uatom", denom)
+
+	_, _, err = input.GravityKeeper.DenomToERC20Lookup(ctx, "uosmo")
+	require.Error(t, err)
+}
+
+func TestERC20DeployedEventRejectsEthereumOriginatedVoucherDenom(t *testing.T) {
+	input := CreateTestEnv(t)
+	ctx := input.Context
+	ethOriginatedContract := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	deployedWrapperContract := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	voucherDenom := types.GravityDenom(ethOriginatedContract)
+
+	require.NoError(t, input.BankKeeper.MintCoins(ctx, types.ModuleName, sdktypes.NewCoins(
+		sdktypes.NewCoin(voucherDenom, sdktypes.NewInt(1)),
+	)))
+
+	err := input.GravityKeeper.Handle(ctx, &types.ERC20DeployedEvent{
+		CosmosDenom:   voucherDenom,
+		TokenContract: deployedWrapperContract.Hex(),
+		Erc20Name:     voucherDenom,
+		Erc20Symbol:   "",
+		Erc20Decimals: 0,
+		EventNonce:    1,
+	})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, types.ErrInvalidERC20Event)
+	require.Contains(t, err.Error(), "ethereum-originated voucher denom")
+
+	_, _, err = input.GravityKeeper.DenomToERC20Lookup(ctx, voucherDenom)
+	require.NoError(t, err)
+
+	isCosmosOriginated, denom := input.GravityKeeper.ERC20ToDenomLookup(ctx, deployedWrapperContract)
+	require.False(t, isCosmosOriginated)
+	require.Equal(t, types.GravityDenom(deployedWrapperContract), denom)
 }


### PR DESCRIPTION
## Summary
- reject ERC20DeployedEvent votes that try to reuse an already mapped token contract for a new Cosmos denom
- reject ERC20 deploy events for ethereum-originated gravity voucher denoms
- add regression tests covering both mapping-poisoning hardening cases

## Tests
- GOCACHE=/private/tmp/gravity-go-build-cache go test -count=1 ./x/gravity/...
- GOCACHE=/private/tmp/gravity-go-build-cache go test -count=1 ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened ERC20 token deployment validation to detect and prevent duplicate token contract mappings
  * Added validation to reject ERC20 deployments for certain voucher denoms, ensuring proper token origin handling

* **Tests**
  * Added comprehensive test coverage for ERC20 deployment validation scenarios, including edge cases for duplicate mappings and voucher denom conflicts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->