### PR TITLE
relayer: support Google Cloud KMS signing

### DIFF
--- a/orchestrator/gravity/src/ethereum/types.rs
+++ b/orchestrator/gravity/src/ethereum/types.rs
@@ -2,7 +2,7 @@ use ethers::{
     prelude::*,
     types::transaction::{eip2718::TypedTransaction, eip712::Eip712},
 };
-use ethers_gcp_kms_signer::GcpKmsSigner;
+use ethers_gcp_kms_signer::{CKMSError, GcpKeyRingRef, GcpKmsProvider, GcpKmsSigner};
 use std::{cmp::Ordering, sync::Arc};
 
 pub type EthSignerMiddleware = SignerMiddleware<Provider<Http>, SignerType>;
@@ -16,6 +16,39 @@ pub enum SignerType {
 }
 
 impl SignerType {
+    /// Construct a signer backed by a Google Cloud KMS asymmetric signing key.
+    ///
+    /// The private key never leaves KMS: every signature is produced by an
+    /// AsymmetricSign API call, so no key material is present in argv, in
+    /// process memory, or on disk. This is the difference that matters versus
+    /// `SignerType::Local`, whose key is passed in as raw bytes and is
+    /// therefore readable from `/proc/<pid>/cmdline` by any local user when
+    /// supplied on a command line.
+    ///
+    /// The key must be `EC_SIGN_SECP256K1_SHA256`; other algorithms will not
+    /// produce recoverable Ethereum signatures. Ambient GCP credentials
+    /// (workload identity, attached service account, or
+    /// GOOGLE_APPLICATION_CREDENTIALS) must hold
+    /// `cloudkms.cryptoKeyVersions.useToSign` and
+    /// `cloudkms.cryptoKeyVersions.viewPublicKey` on the key version.
+    ///
+    /// `chain_id` is bound at construction because GcpKmsSigner captures it;
+    /// callers must therefore resolve the chain ID before building the signer.
+    pub async fn new_gcp_kms(
+        project_id: &str,
+        location: &str,
+        key_ring: &str,
+        key_name: String,
+        key_version: u64,
+        chain_id: u64,
+    ) -> Result<Self, CKMSError> {
+        let key_ring_ref = GcpKeyRingRef::new(project_id, location, key_ring);
+        let provider = GcpKmsProvider::new(key_ring_ref).await?;
+        let signer = GcpKmsSigner::new(provider, key_name, key_version, chain_id).await?;
+
+        Ok(SignerType::GcpKms(signer))
+    }
+
     pub fn normalize(
         &self,
         message: impl AsRef<[u8]>,
@@ -138,7 +171,8 @@ impl Signer for SignerType {
         }?;
 
         // Get the typed data hash for recovery
-        let hash = payload.encode_eip712()
+        let hash = payload
+            .encode_eip712()
             .map_err(|e| ethers::providers::ProviderError::CustomError(e.to_string()))?;
         self.normalize(&hash, &sig)
     }

--- a/orchestrator/gravity/src/ethereum/types.rs
+++ b/orchestrator/gravity/src/ethereum/types.rs
@@ -90,6 +90,33 @@ impl SignerType {
     }
 }
 
+/// Maximum time to wait for a single Google Cloud KMS signing call.
+///
+/// KMS signing is a network RPC. The relayer's main loop drives valset, batch
+/// and logic-call relaying under a single `tokio::join!`, so a signing future
+/// that never resolves stops *all* relaying indefinitely rather than failing
+/// the one submission. The underlying client sets no deadline of its own, so
+/// we impose one here and surface a normal signer error, which the existing
+/// submission paths already log and retry on a later loop iteration.
+const KMS_SIGN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Apply [`KMS_SIGN_TIMEOUT`] to a KMS signing future, mapping both the
+/// signer's own error and a timeout into a `ProviderError`.
+async fn with_kms_timeout<T, E: std::fmt::Display>(
+    what: &str,
+    fut: impl std::future::Future<Output = Result<T, E>>,
+) -> Result<T, ethers::providers::ProviderError> {
+    match tokio::time::timeout(KMS_SIGN_TIMEOUT, fut).await {
+        Ok(Ok(v)) => Ok(v),
+        Ok(Err(e)) => Err(ethers::providers::ProviderError::CustomError(e.to_string())),
+        Err(_) => Err(ethers::providers::ProviderError::CustomError(format!(
+            "GCP KMS {} timed out after {}s",
+            what,
+            KMS_SIGN_TIMEOUT.as_secs()
+        ))),
+    }
+}
+
 #[async_trait::async_trait]
 impl Signer for SignerType {
     type Error = ethers::providers::ProviderError;
@@ -108,10 +135,9 @@ impl Signer for SignerType {
                 .sign_message(message)
                 .await
                 .map_err(|e| ethers::providers::ProviderError::CustomError(e.to_string())),
-            SignerType::GcpKms(signer) => signer
-                .sign_message(message)
-                .await
-                .map_err(|e| ethers::providers::ProviderError::CustomError(e.to_string())),
+            SignerType::GcpKms(signer) => {
+                with_kms_timeout("sign_message", signer.sign_message(message)).await
+            }
         }?;
 
         self.normalize(msg, &sig)
@@ -123,10 +149,9 @@ impl Signer for SignerType {
                 .sign_transaction(tx)
                 .await
                 .map_err(|e| ethers::providers::ProviderError::CustomError(e.to_string())),
-            SignerType::GcpKms(signer) => signer
-                .sign_transaction(tx)
-                .await
-                .map_err(|e| ethers::providers::ProviderError::CustomError(e.to_string())),
+            SignerType::GcpKms(signer) => {
+                with_kms_timeout("sign_transaction", signer.sign_transaction(tx)).await
+            }
         }?;
 
         // Get the transaction hash for recovery
@@ -164,10 +189,9 @@ impl Signer for SignerType {
                 .sign_typed_data(payload)
                 .await
                 .map_err(|e| ethers::providers::ProviderError::CustomError(e.to_string())),
-            SignerType::GcpKms(signer) => signer
-                .sign_typed_data(payload)
-                .await
-                .map_err(|e| ethers::providers::ProviderError::CustomError(e.to_string())),
+            SignerType::GcpKms(signer) => {
+                with_kms_timeout("sign_typed_data", signer.sign_typed_data(payload)).await
+            }
         }?;
 
         // Get the typed data hash for recovery

--- a/orchestrator/relayer/src/main.rs
+++ b/orchestrator/relayer/src/main.rs
@@ -29,7 +29,12 @@ extern crate log;
 
 #[derive(Debug, Deserialize)]
 struct Args {
-    flag_ethereum_key: String,
+    flag_ethereum_key: Option<String>,
+    flag_gcp_kms_project: Option<String>,
+    flag_gcp_kms_location: Option<String>,
+    flag_gcp_kms_key_ring: Option<String>,
+    flag_gcp_kms_key_name: Option<String>,
+    flag_gcp_kms_key_version: Option<u64>,
     flag_cosmos_grpc: String,
     flag_address_prefix: String,
     flag_ethereum_rpc: String,
@@ -38,10 +43,15 @@ struct Args {
 
 lazy_static! {
     pub static ref USAGE: String = format!(
-    "Usage: {} --ethereum-key=<key> --cosmos-grpc=<url> --address-prefix=<prefix> --ethereum-rpc=<url> --contract-address=<addr>
+    "Usage: {} [--ethereum-key=<key>] [--gcp-kms-project=<id>] [--gcp-kms-location=<loc>] [--gcp-kms-key-ring=<ring>] [--gcp-kms-key-name=<name>] [--gcp-kms-key-version=<ver>] --cosmos-grpc=<url> --address-prefix=<prefix> --ethereum-rpc=<url> --contract-address=<addr>
         Options:
             -h --help                    Show this screen.
-            --ethereum-key=<ekey>        An Ethereum private key containing non-trivial funds, or the literal value kms
+            --ethereum-key=<key>         An Ethereum private key containing non-trivial funds
+            --gcp-kms-project=<id>       Google Cloud project id holding the Kms key ring
+            --gcp-kms-location=<loc>     Google Cloud location of the Kms key ring
+            --gcp-kms-key-ring=<ring>    Kms key ring name
+            --gcp-kms-key-name=<name>    Kms key name, must be a secp256k1 signing key
+            --gcp-kms-key-version=<ver>  Kms key version, required, each version has its own address
             --cosmos-grpc=<gurl>         The Cosmos gRPC url
             --address-prefix=<prefix>    The prefix for addresses on this Cosmos chain
             --ethereum-rpc=<eurl>        The Ethereum RPC url, Geth light clients work and sync fast
@@ -51,15 +61,12 @@ lazy_static! {
             to the Ethereum blockchain, cosmos key and fees are optional since they are only used
             to request the creation of batches or validator sets to relay.
             for Althea-Gravity.
-            Signing. Passing a raw Ethereum private key is discouraged, because it is
-            visible in the process table to every local user on the host. Instead pass
-            the literal value kms, which signs through Google Cloud Kms so that the
-            private key never leaves Kms. That mode reads its configuration from these
-            environment variables, all of which are required.
-            Gravity_Gcp_Kms_Project, Gravity_Gcp_Kms_Location, Gravity_Gcp_Kms_Key_Ring,
-            Gravity_Gcp_Kms_Key_Name and Gravity_Gcp_Kms_Key_Version, upper cased.
-            The key must be a secp256k1 signing key. Each key version has its own
-            Ethereum address, which pays relayer gas and must be funded before use.
+            Signing. Supply exactly one signing method. An Ethereum private key is
+            discouraged, because it is visible in the process table to every local user
+            on the host. Prefer the Google Cloud Kms options, where the private key never
+            leaves Kms. All five Kms options are required together. Each Kms key version
+            has its own Ethereum address, which pays relayer gas and must be funded
+            before use.
             Written By: {}
             Version {}",
             env!("CARGO_PKG_NAME"),
@@ -75,7 +82,11 @@ lazy_static! {
 enum SigningConfig {
     /// Raw private key supplied on the command line. Readable via
     /// /proc/<pid>/cmdline by any local user; retained for compatibility.
-    Local(String),
+    ///
+    /// Held already-parsed so that a malformed key is rejected during argument
+    /// handling, before any network work, as it was before KMS support moved
+    /// signer construction below chain-ID resolution.
+    Local(Box<EthWallet>),
     /// Google Cloud KMS. No key material is held by this process.
     GcpKms {
         project: String,
@@ -86,70 +97,113 @@ enum SigningConfig {
     },
 }
 
+/// Hand-written rather than derived: the `Local` variant holds a raw private
+/// key, and a derived `Debug` would print it in full anywhere this value is
+/// formatted, which is the exact class of leak this whole change exists to
+/// close. The KMS variant holds only a key reference, so it prints in full.
+impl std::fmt::Debug for SigningConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SigningConfig::Local(_) => f.write_str("Local(<redacted>)"),
+            SigningConfig::GcpKms {
+                project,
+                location,
+                key_ring,
+                key_name,
+                key_version,
+            } => write!(
+                f,
+                "GcpKms(projects/{}/locations/{}/keyRings/{}/cryptoKeys/{}/cryptoKeyVersions/{})",
+                project, location, key_ring, key_name, key_version
+            ),
+        }
+    }
+}
+
 impl SigningConfig {
-    /// All required. The key version is deliberately required rather than
-    /// defaulted: a GCP KMS signing address is version-specific, so silently
-    /// pinning to version 1 would both survive a key rotation without picking
-    /// it up (relaying stops when version 1 is disabled) and hide the fact
-    /// that moving versions changes the Ethereum address, which must be
-    /// funded for gas before it can relay.
-    const KMS_VARS: [&'static str; 5] = [
-        "GRAVITY_GCP_KMS_PROJECT",
-        "GRAVITY_GCP_KMS_LOCATION",
-        "GRAVITY_GCP_KMS_KEY_RING",
-        "GRAVITY_GCP_KMS_KEY_NAME",
-        "GRAVITY_GCP_KMS_KEY_VERSION",
+    /// The GCP KMS options, which are all required together. The key version is
+    /// deliberately required rather than defaulted: a KMS signing address is
+    /// version-specific, so silently pinning to version 1 would both fail to
+    /// follow a key rotation (relaying stops once version 1 is disabled) and
+    /// hide the fact that changing version changes the Ethereum address, which
+    /// must be funded for gas before it can relay.
+    const KMS_FLAGS: [&'static str; 5] = [
+        "--gcp-kms-project",
+        "--gcp-kms-location",
+        "--gcp-kms-key-ring",
+        "--gcp-kms-key-name",
+        "--gcp-kms-key-version",
     ];
 
-    /// Sentinel value for --ethereum-key that selects the GCP KMS signer.
-    const KMS_SENTINEL: &'static str = "kms";
-
-    fn from_args(args: &Args) -> Self {
-        if args.flag_ethereum_key != Self::KMS_SENTINEL {
-            warn!(
-                "Signing with a raw --ethereum-key. This key is visible in the process \
-                 table to every local user on this host. Prefer GCP KMS: pass \
-                 --ethereum-key={} and set {}, so the key never leaves KMS.",
-                Self::KMS_SENTINEL,
-                Self::KMS_VARS.join(", ")
-            );
-            return SigningConfig::Local(args.flag_ethereum_key.clone());
-        }
-
-        let missing: Vec<&str> = Self::KMS_VARS
+    /// Resolve the signing method from CLI flags.
+    ///
+    /// Returns `Err` with an operator-facing message rather than panicking, so
+    /// that a misconfiguration produces a clean exit instead of a backtrace.
+    fn from_args(args: &Args) -> Result<Self, String> {
+        let supplied: Vec<&str> = Self::KMS_FLAGS
             .iter()
-            .filter(|v| std::env::var(v).is_err())
+            .zip([
+                args.flag_gcp_kms_project.is_some(),
+                args.flag_gcp_kms_location.is_some(),
+                args.flag_gcp_kms_key_ring.is_some(),
+                args.flag_gcp_kms_key_name.is_some(),
+                args.flag_gcp_kms_key_version.is_some(),
+            ])
+            .filter(|(_, present)| *present)
+            .map(|(name, _)| *name)
+            .collect();
+        let missing: Vec<&str> = Self::KMS_FLAGS
+            .iter()
+            .filter(|f| !supplied.contains(f))
             .copied()
             .collect();
-        if !missing.is_empty() {
-            panic!(
-                "--ethereum-key={} selects the GCP KMS signer, but these required \
-                 environment variables are unset: {}.",
-                Self::KMS_SENTINEL,
-                missing.join(", ")
-            );
-        }
 
-        let get = |v: &str| std::env::var(v).unwrap();
-        let key_version = get("GRAVITY_GCP_KMS_KEY_VERSION")
-            .parse::<u64>()
-            .expect("GRAVITY_GCP_KMS_KEY_VERSION must be a positive integer");
-
-        SigningConfig::GcpKms {
-            project: get("GRAVITY_GCP_KMS_PROJECT"),
-            location: get("GRAVITY_GCP_KMS_LOCATION"),
-            key_ring: get("GRAVITY_GCP_KMS_KEY_RING"),
-            key_name: get("GRAVITY_GCP_KMS_KEY_NAME"),
-            key_version,
+        match (args.flag_ethereum_key.as_ref(), supplied.is_empty()) {
+            (Some(_), false) => Err(format!(
+                "Both signing methods configured. --ethereum-key was supplied together \
+                 with {}. Supply exactly one signing method so it is unambiguous which \
+                 key signs.",
+                supplied.join(", ")
+            )),
+            (None, true) => Err(format!(
+                "No signing method configured. Supply either --ethereum-key or all of {}.",
+                Self::KMS_FLAGS.join(", ")
+            )),
+            (Some(key), true) => {
+                warn!(
+                    "Signing with a raw --ethereum-key. This key is visible in the process \
+                     table to every local user on this host. Prefer {}, so that the key \
+                     never leaves KMS.",
+                    Self::KMS_FLAGS.join(", ")
+                );
+                let wallet: EthWallet = key
+                    .parse()
+                    .map_err(|e| format!("Invalid Ethereum private key: {}", e))?;
+                Ok(SigningConfig::Local(Box::new(wallet)))
+            }
+            (None, false) => {
+                if !missing.is_empty() {
+                    return Err(format!(
+                        "Incomplete GCP KMS configuration. Supplied {}, but these are also \
+                         required: {}.",
+                        supplied.join(", "),
+                        missing.join(", ")
+                    ));
+                }
+                Ok(SigningConfig::GcpKms {
+                    project: args.flag_gcp_kms_project.clone().unwrap(),
+                    location: args.flag_gcp_kms_location.clone().unwrap(),
+                    key_ring: args.flag_gcp_kms_key_ring.clone().unwrap(),
+                    key_name: args.flag_gcp_kms_key_name.clone().unwrap(),
+                    key_version: args.flag_gcp_kms_key_version.unwrap(),
+                })
+            }
         }
     }
 
-    async fn into_signer(self, chain_id: u64) -> SignerType {
+    async fn into_signer(self, chain_id: u64) -> Result<SignerType, String> {
         match self {
-            SigningConfig::Local(key) => {
-                let wallet: EthWallet = key.parse().expect("Invalid Ethereum private key!");
-                SignerType::Local(wallet).with_chain_id(chain_id)
-            }
+            SigningConfig::Local(wallet) => Ok(SignerType::Local(*wallet).with_chain_id(chain_id)),
             SigningConfig::GcpKms {
                 project,
                 location,
@@ -170,7 +224,7 @@ impl SigningConfig {
                     chain_id,
                 )
                 .await
-                .expect("Failed to construct GCP KMS signer")
+                .map_err(|e| format!("Failed to construct GCP KMS signer: {}", e))
             }
         }
     }
@@ -189,7 +243,10 @@ async fn main() {
         .unwrap_or_else(|e| e.exit());
     // Decide how we will sign before doing any network work, so a
     // misconfiguration fails immediately rather than after connecting.
-    let signing_config = SigningConfig::from_args(&args);
+    let signing_config = SigningConfig::from_args(&args).unwrap_or_else(|e| {
+        error!("{}", e);
+        std::process::exit(1);
+    });
 
     let gravity_contract_address: EthAddress = args
         .flag_contract_address
@@ -212,7 +269,13 @@ async fn main() {
 
     // GcpKmsSigner binds chain_id at construction, so the signer can only be
     // built once the chain ID is known.
-    let ethereum_wallet = signing_config.into_signer(chain_id).await;
+    let ethereum_wallet = signing_config
+        .into_signer(chain_id)
+        .await
+        .unwrap_or_else(|e| {
+            error!("{}", e);
+            std::process::exit(1);
+        });
 
     let eth_client = SignerMiddleware::new(provider, ethereum_wallet);
     let eth_client = Arc::new(eth_client);
@@ -237,4 +300,164 @@ async fn main() {
         1.1f32,
     )
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Args with neither signing method configured. Non-signing fields are
+    /// irrelevant to SigningConfig resolution but must be present.
+    fn bare_args() -> Args {
+        Args {
+            flag_ethereum_key: None,
+            flag_gcp_kms_project: None,
+            flag_gcp_kms_location: None,
+            flag_gcp_kms_key_ring: None,
+            flag_gcp_kms_key_name: None,
+            flag_gcp_kms_key_version: None,
+            flag_cosmos_grpc: "http://localhost:9090".to_string(),
+            flag_address_prefix: "somm".to_string(),
+            flag_ethereum_rpc: "http://localhost:8545".to_string(),
+            flag_contract_address: "0x69592e6f9d21989a043646fE8225da2600e5A0f7".to_string(),
+        }
+    }
+
+    fn full_kms_args() -> Args {
+        Args {
+            flag_gcp_kms_project: Some("somm-production-validator".to_string()),
+            flag_gcp_kms_location: Some("us-central1".to_string()),
+            flag_gcp_kms_key_ring: Some("somm-production-keyring".to_string()),
+            flag_gcp_kms_key_name: Some("sommelier-primary-eth-signer".to_string()),
+            flag_gcp_kms_key_version: Some(1),
+            ..bare_args()
+        }
+    }
+
+    #[test]
+    fn no_signing_method_is_rejected() {
+        let err = SigningConfig::from_args(&bare_args()).unwrap_err();
+        assert!(err.contains("No signing method configured"), "{}", err);
+    }
+
+    /// A valid 32-byte secp256k1 key.
+    const TEST_KEY: &str = "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+    #[test]
+    fn raw_key_selects_local() {
+        let args = Args {
+            flag_ethereum_key: Some(TEST_KEY.to_string()),
+            ..bare_args()
+        };
+        match SigningConfig::from_args(&args).unwrap() {
+            SigningConfig::Local(_) => {}
+            other => panic!("expected Local signer, got {:?}", other),
+        }
+    }
+
+    /// The `Local` variant holds a private key, so its Debug must never print
+    /// it. This is the leak class the whole change exists to close.
+    #[test]
+    fn local_debug_redacts_the_key() {
+        let args = Args {
+            flag_ethereum_key: Some(TEST_KEY.to_string()),
+            ..bare_args()
+        };
+        let cfg = SigningConfig::from_args(&args).unwrap();
+        let rendered = format!("{:?}", cfg);
+        assert!(!rendered.contains("0000000000000000"), "{}", rendered);
+        assert!(rendered.contains("redacted"), "{}", rendered);
+    }
+
+    #[test]
+    fn full_kms_flags_select_kms() {
+        match SigningConfig::from_args(&full_kms_args()).unwrap() {
+            SigningConfig::GcpKms {
+                project,
+                location,
+                key_ring,
+                key_name,
+                key_version,
+            } => {
+                assert_eq!(project, "somm-production-validator");
+                assert_eq!(location, "us-central1");
+                assert_eq!(key_ring, "somm-production-keyring");
+                assert_eq!(key_name, "sommelier-primary-eth-signer");
+                assert_eq!(key_version, 1);
+            }
+            _ => panic!("expected GcpKms signer"),
+        }
+    }
+
+    #[test]
+    fn both_methods_are_rejected() {
+        let args = Args {
+            flag_ethereum_key: Some("0xdeadbeef".to_string()),
+            ..full_kms_args()
+        };
+        let err = SigningConfig::from_args(&args).unwrap_err();
+        assert!(err.contains("Both signing methods configured"), "{}", err);
+    }
+
+    /// Every proper subset of the KMS flags must be rejected, and the message
+    /// must name what is missing. This is the case most likely to bite an
+    /// operator mid-migration, so it is checked exhaustively rather than for a
+    /// single representative subset.
+    #[test]
+    fn every_partial_kms_combination_is_rejected() {
+        let full = full_kms_args();
+        // Bit i set means "supply flag i". 0 is the no-method case, which is
+        // covered separately; 31 is the complete set.
+        for mask in 1..31u8 {
+            let args = Args {
+                flag_gcp_kms_project: (mask & 1 != 0)
+                    .then(|| full.flag_gcp_kms_project.clone().unwrap()),
+                flag_gcp_kms_location: (mask & 2 != 0)
+                    .then(|| full.flag_gcp_kms_location.clone().unwrap()),
+                flag_gcp_kms_key_ring: (mask & 4 != 0)
+                    .then(|| full.flag_gcp_kms_key_ring.clone().unwrap()),
+                flag_gcp_kms_key_name: (mask & 8 != 0)
+                    .then(|| full.flag_gcp_kms_key_name.clone().unwrap()),
+                flag_gcp_kms_key_version: (mask & 16 != 0).then_some(1),
+                ..bare_args()
+            };
+            let err = SigningConfig::from_args(&args)
+                .err()
+                .unwrap_or_else(|| panic!("mask {} should not have produced a signer", mask));
+            assert!(
+                err.contains("Incomplete GCP KMS configuration"),
+                "mask {}: {}",
+                mask,
+                err
+            );
+        }
+    }
+
+    /// The key version must never be silently defaulted: a KMS signing address
+    /// is version-specific, so a default would pin to a version the operator
+    /// did not choose and whose Ethereum address may hold no gas.
+    #[test]
+    fn missing_key_version_is_rejected() {
+        let args = Args {
+            flag_gcp_kms_key_version: None,
+            ..full_kms_args()
+        };
+        let err = SigningConfig::from_args(&args).unwrap_err();
+        assert!(err.contains("--gcp-kms-key-version"), "{}", err);
+    }
+
+    /// An invalid raw key must surface as a clean error rather than a panic,
+    /// and must do so during argument handling, before any network work. The
+    /// original code parsed the key at the top of main; KMS support moved
+    /// signer construction below chain-ID resolution, so this guards against
+    /// the key check drifting back after connection setup.
+    #[test]
+    fn invalid_raw_key_is_rejected_during_arg_handling() {
+        let args = Args {
+            flag_ethereum_key: Some("not-a-key".to_string()),
+            ..bare_args()
+        };
+        let err = SigningConfig::from_args(&args).unwrap_err();
+        assert!(err.contains("Invalid Ethereum private key"), "{}", err);
+    }
 }

--- a/orchestrator/relayer/src/main.rs
+++ b/orchestrator/relayer/src/main.rs
@@ -59,6 +59,111 @@ lazy_static! {
         );
 }
 
+/// How the relayer will obtain Ethereum signatures.
+///
+/// Resolved from CLI flags up front so that an invalid combination aborts
+/// before any network connections are made.
+enum SigningConfig {
+    /// Raw private key supplied on the command line. Readable via
+    /// /proc/<pid>/cmdline by any local user; retained for compatibility.
+    Local(String),
+    /// Google Cloud KMS. No key material is held by this process.
+    GcpKms {
+        project: String,
+        location: String,
+        key_ring: String,
+        key_name: String,
+        key_version: u64,
+    },
+}
+
+impl SigningConfig {
+    const KMS_VARS: [&'static str; 4] = [
+        "GRAVITY_GCP_KMS_PROJECT",
+        "GRAVITY_GCP_KMS_LOCATION",
+        "GRAVITY_GCP_KMS_KEY_RING",
+        "GRAVITY_GCP_KMS_KEY_NAME",
+    ];
+
+    /// Sentinel value for --ethereum-key that selects the GCP KMS signer.
+    const KMS_SENTINEL: &'static str = "kms";
+
+    fn from_args(args: &Args) -> Self {
+        if args.flag_ethereum_key != Self::KMS_SENTINEL {
+            warn!(
+                "Signing with a raw --ethereum-key. This key is visible in the process \
+                 table to every local user on this host. Prefer GCP KMS: pass \
+                 --ethereum-key={} and set {}, so the key never leaves KMS.",
+                Self::KMS_SENTINEL,
+                Self::KMS_VARS.join(", ")
+            );
+            return SigningConfig::Local(args.flag_ethereum_key.clone());
+        }
+
+        let missing: Vec<&str> = Self::KMS_VARS
+            .iter()
+            .filter(|v| std::env::var(v).is_err())
+            .copied()
+            .collect();
+        if !missing.is_empty() {
+            panic!(
+                "--ethereum-key={} selects the GCP KMS signer, but these required \
+                 environment variables are unset: {}.",
+                Self::KMS_SENTINEL,
+                missing.join(", ")
+            );
+        }
+
+        let get = |v: &str| std::env::var(v).unwrap();
+        let key_version = std::env::var("GRAVITY_GCP_KMS_KEY_VERSION")
+            .ok()
+            .map(|v| {
+                v.parse::<u64>()
+                    .expect("GRAVITY_GCP_KMS_KEY_VERSION must be an integer")
+            })
+            .unwrap_or(1);
+
+        SigningConfig::GcpKms {
+            project: get("GRAVITY_GCP_KMS_PROJECT"),
+            location: get("GRAVITY_GCP_KMS_LOCATION"),
+            key_ring: get("GRAVITY_GCP_KMS_KEY_RING"),
+            key_name: get("GRAVITY_GCP_KMS_KEY_NAME"),
+            key_version,
+        }
+    }
+
+    async fn into_signer(self, chain_id: u64) -> SignerType {
+        match self {
+            SigningConfig::Local(key) => {
+                let wallet: EthWallet = key.parse().expect("Invalid Ethereum private key!");
+                SignerType::Local(wallet).with_chain_id(chain_id)
+            }
+            SigningConfig::GcpKms {
+                project,
+                location,
+                key_ring,
+                key_name,
+                key_version,
+            } => {
+                info!(
+                    "Using GCP KMS signer: projects/{}/locations/{}/keyRings/{}/cryptoKeys/{}/cryptoKeyVersions/{}",
+                    project, location, key_ring, key_name, key_version
+                );
+                SignerType::new_gcp_kms(
+                    &project,
+                    &location,
+                    &key_ring,
+                    key_name,
+                    key_version,
+                    chain_id,
+                )
+                .await
+                .expect("Failed to construct GCP KMS signer")
+            }
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
@@ -70,11 +175,10 @@ async fn main() {
     let args: Args = Docopt::new(USAGE.as_str())
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());
-    let ethereum_wallet: EthWallet = args
-        .flag_ethereum_key
-        .parse()
-        .expect("Invalid Ethereum private key!");
-    let ethereum_wallet = SignerType::Local(ethereum_wallet);
+    // Decide how we will sign before doing any network work, so a
+    // misconfiguration fails immediately rather than after connecting.
+    let signing_config = SigningConfig::from_args(&args);
+
     let gravity_contract_address: EthAddress = args
         .flag_contract_address
         .parse()
@@ -93,8 +197,12 @@ async fn main() {
         .await
         .expect("Could not retrieve chain ID during relayer start");
     let chain_id = downcast_to_u64(chain_id).expect("Chain ID overflowed when downcasting to u64");
-    let eth_client =
-        SignerMiddleware::new(provider, ethereum_wallet.clone().with_chain_id(chain_id));
+
+    // GcpKmsSigner binds chain_id at construction, so the signer can only be
+    // built once the chain ID is known.
+    let ethereum_wallet = signing_config.into_signer(chain_id).await;
+
+    let eth_client = SignerMiddleware::new(provider, ethereum_wallet);
     let eth_client = Arc::new(eth_client);
 
     let public_eth_key = eth_client.address();

--- a/orchestrator/relayer/src/main.rs
+++ b/orchestrator/relayer/src/main.rs
@@ -41,7 +41,7 @@ lazy_static! {
     "Usage: {} --ethereum-key=<key> --cosmos-grpc=<url> --address-prefix=<prefix> --ethereum-rpc=<url> --contract-address=<addr>
         Options:
             -h --help                    Show this screen.
-            --ethereum-key=<ekey>        An Ethereum private key containing non-trivial funds
+            --ethereum-key=<ekey>        An Ethereum private key containing non-trivial funds, or the literal value kms
             --cosmos-grpc=<gurl>         The Cosmos gRPC url
             --address-prefix=<prefix>    The prefix for addresses on this Cosmos chain
             --ethereum-rpc=<eurl>        The Ethereum RPC url, Geth light clients work and sync fast
@@ -51,6 +51,15 @@ lazy_static! {
             to the Ethereum blockchain, cosmos key and fees are optional since they are only used
             to request the creation of batches or validator sets to relay.
             for Althea-Gravity.
+            Signing. Passing a raw Ethereum private key is discouraged, because it is
+            visible in the process table to every local user on the host. Instead pass
+            the literal value kms, which signs through Google Cloud Kms so that the
+            private key never leaves Kms. That mode reads its configuration from these
+            environment variables, all of which are required.
+            Gravity_Gcp_Kms_Project, Gravity_Gcp_Kms_Location, Gravity_Gcp_Kms_Key_Ring,
+            Gravity_Gcp_Kms_Key_Name and Gravity_Gcp_Kms_Key_Version, upper cased.
+            The key must be a secp256k1 signing key. Each key version has its own
+            Ethereum address, which pays relayer gas and must be funded before use.
             Written By: {}
             Version {}",
             env!("CARGO_PKG_NAME"),
@@ -78,11 +87,18 @@ enum SigningConfig {
 }
 
 impl SigningConfig {
-    const KMS_VARS: [&'static str; 4] = [
+    /// All required. The key version is deliberately required rather than
+    /// defaulted: a GCP KMS signing address is version-specific, so silently
+    /// pinning to version 1 would both survive a key rotation without picking
+    /// it up (relaying stops when version 1 is disabled) and hide the fact
+    /// that moving versions changes the Ethereum address, which must be
+    /// funded for gas before it can relay.
+    const KMS_VARS: [&'static str; 5] = [
         "GRAVITY_GCP_KMS_PROJECT",
         "GRAVITY_GCP_KMS_LOCATION",
         "GRAVITY_GCP_KMS_KEY_RING",
         "GRAVITY_GCP_KMS_KEY_NAME",
+        "GRAVITY_GCP_KMS_KEY_VERSION",
     ];
 
     /// Sentinel value for --ethereum-key that selects the GCP KMS signer.
@@ -115,13 +131,9 @@ impl SigningConfig {
         }
 
         let get = |v: &str| std::env::var(v).unwrap();
-        let key_version = std::env::var("GRAVITY_GCP_KMS_KEY_VERSION")
-            .ok()
-            .map(|v| {
-                v.parse::<u64>()
-                    .expect("GRAVITY_GCP_KMS_KEY_VERSION must be an integer")
-            })
-            .unwrap_or(1);
+        let key_version = get("GRAVITY_GCP_KMS_KEY_VERSION")
+            .parse::<u64>()
+            .expect("GRAVITY_GCP_KMS_KEY_VERSION must be a positive integer");
 
         SigningConfig::GcpKms {
             project: get("GRAVITY_GCP_KMS_PROJECT"),


### PR DESCRIPTION
## Why

The relayer accepted only a raw Ethereum private key via `--ethereum-key=0x...`, which is world-readable in `/proc/<pid>/cmdline`. On the production validator host that key was in fact exposed in the process table to every local account on the box.

`SignerType` already had a `GcpKms` variant and the `gravity` crate already depended on `ethers-gcp-kms-signer`, but nothing ever constructed a `GcpKmsSigner` — the KMS path was dead code. This wires it up.

Scope note: the relayer key pays **gas** to submit already-validator-signed batches. Relaying is permissionless, so this key does not authorize bridge transfers; exposure means gas-account drain and relaying disruption, not theft of bridge funds.

## What

- `SignerType::new_gcp_kms()` — wires `GcpKeyRingRef` → `GcpKmsProvider` → `GcpKmsSigner`.
- New `--gcp-kms-project`, `--gcp-kms-location`, `--gcp-kms-key-ring`, `--gcp-kms-key-name`, `--gcp-kms-key-version` flags. Supply exactly one signing method; `--ethereum-key` still works and now warns about process-table exposure.
- **30s timeout on all KMS signing calls.** KMS signing is a network RPC with no deadline of its own, and the main loop drives valset, batch and logic-call relaying under a single `tokio::join!` — so a signing future that never resolved would have stopped *all* relaying rather than failing one submission. Timeouts surface as normal signer errors, which existing callers already log and retry.
- **`--gcp-kms-key-version` is required, not defaulted.** A KMS signing address is version-specific: a silent default to 1 would fail to follow a rotation (relaying stops once v1 is disabled) and would hide that changing version changes the gas-paying Ethereum address.
- Configuration errors return `Result` and exit cleanly instead of panicking.
- Raw keys are parsed during argument handling, preserving the original fail-fast behaviour (constructing the KMS signer requires the chain ID, so signer construction moved below chain-ID resolution; key validation deliberately did not).
- `Debug` is hand-written, not derived — the `Local` variant holds a private key and a derived impl would print it in full.

## Testing

8 unit tests: signer selection, both-methods and no-method rejection, all 30 partial KMS flag combinations, eager key validation, and `Debug` redaction. `cargo build` and `cargo clippy` clean.

**Not tested end to end:** actual KMS signature production. `GcpKmsSigner::new` needs live GCP credentials, and the `SignerType::normalize` v-recovery path for KMS signatures has not been exercised against the real Gravity contract. Given main already carries #581 ("Normalize v in KMS signature"), that path warrants a testnet run before any mainnet cutover.

## Operator notes

Each KMS key version has its own Ethereum address, which pays relayer gas and **must be funded before switching**. For `sommelier-primary-eth-signer` v1 that address is `0xe1a9190c225300468826736adec52fd2577a6e16`, currently holding 0.001 ETH with nonce 0 — it has never sent a transaction, so it is not the account relaying today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for signing Ethereum transactions with Google Cloud KMS.
  * Added command-line configuration for selecting either a local private key or Google Cloud KMS.
  * Added validation to prevent incomplete or conflicting signing configurations.

* **Bug Fixes**
  * Added signing timeouts and clearer error handling for failed or unresponsive KMS operations.
  * Improved protection of sensitive local signing keys in diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->