### PR TITLE
fix(gravity): decouple outgoing-tx timeout cleanup from height-vote consensus (GHSA-4vf2-m5pw-3r3r)

### DIFF
--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -268,13 +268,16 @@ func updateObservedEthereumHeight(ctx sdk.Context, k keeper.Keeper) {
 // this means that we MUST only cleanup a single batch at a time
 //
 // B) it is possible for ethereumHeight to be zero if no events have ever occurred, make sure your code accounts for this
-// C) When we compute the timeout we do our best to estimate the Ethereum block height at that very second. But what we work with
-//
-//	here is the Ethereum block height at the time of the last Deposit or Withdraw to be observed. It's very important we do not
-//	project, if we do a slowdown on ethereum could cause a double spend. Instead timeouts will *only* occur after the timeout period
-//	AND any deposit or withdraw has occurred to update the Ethereum block height.
+// C) We rely on the *event-observed* Ethereum block height — i.e. the height of the most
+// recently applied EthereumEvent attestation — NOT the height-vote-derived value used elsewhere.
+// The MsgEthereumHeightVote / updateObservedEthereumHeight consensus advances independently of
+// attestations. Cancelling based on that value would let us cancel a batch whose
+// BatchExecutedEvent has already been emitted on Ethereum but is still pending under the
+// attestation threshold; the contained transactions could then be re-batched and executed a
+// second time on Ethereum, or refunded via MsgCancelSendToEthereum, while the bridge contract
+// has already paid out. Always read GetLastEventObservedEthereumBlockHeight here.
 func cleanupTimedOutBatchTxs(ctx sdk.Context, k keeper.Keeper) {
-	ethereumHeight := k.GetLastObservedEthereumBlockHeight(ctx).EthereumHeight
+	ethereumHeight := k.GetLastEventObservedEthereumBlockHeight(ctx).EthereumHeight
 	k.IterateOutgoingTxsByType(ctx, types.BatchTxPrefixByte, func(key []byte, otx types.OutgoingTx) bool {
 		btx, _ := otx.(*types.BatchTx)
 
@@ -295,13 +298,11 @@ func cleanupTimedOutBatchTxs(ctx sdk.Context, k keeper.Keeper) {
 //	this means that we MUST only cleanup a single call at a time
 //
 // B) it is possible for ethereumHeight to be zero if no events have ever occurred, make sure your code accounts for this
-// C) When we compute the timeout we do our best to estimate the Ethereum block height at that very second. But what we work with
-//
-//	here is the Ethereum block height at the time of the last Deposit or Withdraw to be observed. It's very important we do not
-//	project, if we do a slowdown on ethereum could cause a double spend. Instead timeouts will *only* occur after the timeout period
-//	AND any deposit or withdraw has occurred to update the Ethereum block height.
+// C) Same safety constraint as cleanupTimedOutBatchTxs: read the event-observed height so a
+// pending ContractCallExecutedEvent under attestation threshold cannot be skipped past by
+// height-vote consensus.
 func cleanupTimedOutContractCallTxs(ctx sdk.Context, k keeper.Keeper) {
-	ethereumHeight := k.GetLastObservedEthereumBlockHeight(ctx).EthereumHeight
+	ethereumHeight := k.GetLastEventObservedEthereumBlockHeight(ctx).EthereumHeight
 	k.IterateOutgoingTxsByType(ctx, types.ContractCallTxPrefixByte, func(_ []byte, otx types.OutgoingTx) bool {
 		cctx, _ := otx.(*types.ContractCallTx)
 		if cctx.Timeout < ethereumHeight {

--- a/module/x/gravity/abci_test.go
+++ b/module/x/gravity/abci_test.go
@@ -519,6 +519,81 @@ func TestBatchTxTimeoutRequiresEventObservedHeight(t *testing.T) {
 		"batch should be cancelled once an event is observed past its timeout")
 }
 
+// TestMigrateStoreV6ToV7DoesNotSeedTaintedHeight covers the upgrade-boundary
+// failure modes flagged during code review:
+//
+//  1. The pre-upgrade LastObservedEthereumBlockHeight may be ahead of any event
+//     actually applied via attestation (because MsgEthereumHeightVote consensus
+//     advances it independently). Seeding the new key from it would re-open
+//     the timeout race for one BeginBlocker after upgrade.
+//  2. SetLastEventObservedEthereumBlockHeight panics on rollback. Seeding the
+//     new key with the tainted value and then applying the still-pending lower-
+//     height event would halt the chain.
+//
+// The migration must therefore leave the new key unset; cleanup pauses until
+// the next attested event, then resumes correctly.
+func TestMigrateStoreV6ToV7DoesNotSeedTaintedHeight(t *testing.T) {
+	input, ctx := keeper.SetupFiveValChain(t)
+	gravityKeeper := input.GravityKeeper
+	params := gravityKeeper.GetParams(ctx)
+	var (
+		now                 = time.Now().UTC()
+		mySender, _         = sdk.AccAddressFromBech32("cosmos1ahx7f8wyertuus9r20284ej0asrs085case3kn")
+		myReceiver          = common.HexToAddress("0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7")
+		myTokenContractAddr = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5")
+		allVouchers         = sdk.NewCoins(types.NewERC20Token(99999, myTokenContractAddr).GravityCoin())
+	)
+
+	require.Greater(t, params.AverageBlockTime, uint64(0))
+	require.Greater(t, params.AverageEthereumBlockTime, uint64(0))
+
+	require.NoError(t, input.BankKeeper.MintCoins(ctx, types.ModuleName, allVouchers))
+	input.AccountKeeper.NewAccountWithAddress(ctx, mySender)
+	require.NoError(t, fundAccount(ctx, input.BankKeeper, mySender, allVouchers))
+
+	input.AddSendToEthTxsToPoolWithFee(t, ctx, myTokenContractAddr, mySender, myReceiver, 6, 10)
+
+	// Pre-upgrade state: the legacy LastObservedEthereumBlockHeight has been
+	// advanced by MsgEthereumHeightVote consensus; the event-observed key does
+	// not yet exist (we are simulating the v6 chain on the cusp of upgrading).
+	ctx = ctx.WithBlockTime(now).WithBlockHeight(250)
+	gravityKeeper.SetLastObservedEthereumBlockHeight(ctx, 500)
+	batch := gravityKeeper.CreateBatchTx(ctx, myTokenContractAddr, 1)
+	require.NotNil(t, batch)
+	batchTimeout := batch.Timeout
+	require.Greater(t, batchTimeout, uint64(0))
+	storeKey := types.MakeBatchTxKey(common.HexToAddress(batch.TokenContract), batch.BatchNonce)
+
+	// Height-vote consensus pushes the legacy key past the batch timeout while
+	// the corresponding BatchExecutedEvent is still pending under threshold.
+	taintedHeight := batchTimeout + 100
+	gravityKeeper.SetLastObservedEthereumBlockHeight(ctx, taintedHeight)
+
+	// Run the v6 -> v7 migration.
+	migrator := keeper.NewMigrator(gravityKeeper)
+	require.NoError(t, migrator.MigrateStoreV6ToV7(ctx))
+
+	// Critical post-migration invariants:
+	//   (a) the new key MUST NOT be seeded with the tainted height.
+	postMigrationHeight := gravityKeeper.GetLastEventObservedEthereumBlockHeight(ctx)
+	require.Equal(t, uint64(0), postMigrationHeight.EthereumHeight,
+		"migration must not seed LastEventObservedEthereumBlockHeight from the legacy (vote-tainted) key")
+
+	//   (b) BeginBlocker cleanup MUST NOT fire on the tainted height.
+	gravity.BeginBlocker(ctx, gravityKeeper)
+	require.NotNil(t, gravityKeeper.GetOutgoingTx(ctx, storeKey),
+		"batch must not be cancelled immediately after upgrade based on the legacy vote-tainted height")
+
+	//   (c) Applying the previously-pending event at a height BELOW the tainted
+	//       legacy value MUST NOT panic. The event-observed setter is monotonic;
+	//       if the migration had seeded the new key with taintedHeight, this
+	//       call would halt the chain.
+	pendingEventHeight := batchTimeout - 1
+	require.NotPanics(t, func() {
+		gravityKeeper.SetLastEventObservedEthereumBlockHeight(ctx, pendingEventHeight)
+	}, "applying a pending event at a height below the legacy key must not panic post-upgrade")
+}
+
 func TestUpdateObservedEthereumHeight(t *testing.T) {
 	input, ctx := keeper.SetupFiveValChain(t)
 	gravityKeeper := input.GravityKeeper

--- a/module/x/gravity/abci_test.go
+++ b/module/x/gravity/abci_test.go
@@ -415,6 +415,9 @@ func TestBatchTxTimeout(t *testing.T) {
 	require.Equal(t, b1.Timeout, uint64(0))
 
 	gravityKeeper.SetLastObservedEthereumBlockHeight(ctx, 500)
+	// Cleanup reads the event-observed height; mirror it so getTimeoutHeight
+	// inputs and cleanup inputs stay consistent in this legacy test.
+	gravityKeeper.SetLastEventObservedEthereumBlockHeight(ctx, 500)
 
 	b2 := gravityKeeper.CreateBatchTx(ctx, myTokenContractAddr, 2)
 	require.NotNil(t, b2)
@@ -445,6 +448,7 @@ func TestBatchTxTimeout(t *testing.T) {
 	require.NotNil(t, gotThirdBatch)
 
 	gravityKeeper.SetLastObservedEthereumBlockHeight(ctx, 5000)
+	gravityKeeper.SetLastEventObservedEthereumBlockHeight(ctx, 5000)
 	gravity.BeginBlocker(ctx, gravityKeeper)
 
 	// make sure the end blocker does delete these, as we've got a new Ethereum block height
@@ -454,6 +458,65 @@ func TestBatchTxTimeout(t *testing.T) {
 	require.Nil(t, gotSecondBatch)
 	gotThirdBatch = input.GravityKeeper.GetOutgoingTx(ctx, types.MakeBatchTxKey(common.HexToAddress(b3.TokenContract), b3.BatchNonce))
 	require.NotNil(t, gotThirdBatch)
+}
+
+// TestBatchTxTimeoutRequiresEventObservedHeight verifies that a batch is only
+// cancelled by cleanupTimedOutBatchTxs when an Ethereum event has actually been
+// observed past the batch timeout. Height-vote-driven advances of
+// LastObservedEthereumBlockHeight must NOT trigger cancellation, because the
+// corresponding BatchExecutedEvent for an executed batch could still be pending
+// attestation. Cancelling in that window is the race that allows double-spend.
+func TestBatchTxTimeoutRequiresEventObservedHeight(t *testing.T) {
+	input, ctx := keeper.SetupFiveValChain(t)
+	gravityKeeper := input.GravityKeeper
+	params := gravityKeeper.GetParams(ctx)
+	var (
+		now                 = time.Now().UTC()
+		mySender, _         = sdk.AccAddressFromBech32("cosmos1ahx7f8wyertuus9r20284ej0asrs085case3kn")
+		myReceiver          = common.HexToAddress("0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7")
+		myTokenContractAddr = common.HexToAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5")
+		allVouchers         = sdk.NewCoins(types.NewERC20Token(99999, myTokenContractAddr).GravityCoin())
+	)
+
+	require.Greater(t, params.AverageBlockTime, uint64(0))
+	require.Greater(t, params.AverageEthereumBlockTime, uint64(0))
+
+	require.NoError(t, input.BankKeeper.MintCoins(ctx, types.ModuleName, allVouchers))
+	input.AccountKeeper.NewAccountWithAddress(ctx, mySender)
+	require.NoError(t, fundAccount(ctx, input.BankKeeper, mySender, allVouchers))
+
+	input.AddSendToEthTxsToPoolWithFee(t, ctx, myTokenContractAddr, mySender, myReceiver, 6, 10)
+
+	// Establish an event-observed height so getTimeoutHeight can compute a real
+	// timeout for the batch we create.
+	ctx = ctx.WithBlockTime(now).WithBlockHeight(250)
+	gravityKeeper.SetLastEventObservedEthereumBlockHeight(ctx, 500)
+	gravityKeeper.SetLastObservedEthereumBlockHeight(ctx, 500)
+
+	batch := gravityKeeper.CreateBatchTx(ctx, myTokenContractAddr, 1)
+	require.NotNil(t, batch)
+	batchTimeout := batch.Timeout
+	require.Greater(t, batchTimeout, uint64(0))
+
+	storeKey := types.MakeBatchTxKey(common.HexToAddress(batch.TokenContract), batch.BatchNonce)
+	require.NotNil(t, gravityKeeper.GetOutgoingTx(ctx, storeKey))
+
+	// Simulate a height-vote-driven advance of the public LastObservedEthereumBlockHeight
+	// well past the batch timeout. No BatchExecutedEvent has been observed: the
+	// event-observed height is still 500, below the timeout.
+	gravityKeeper.SetLastObservedEthereumBlockHeight(ctx, batchTimeout+100)
+	gravity.BeginBlocker(ctx, gravityKeeper)
+
+	// The batch must NOT have been cancelled. Cancelling here while the
+	// BatchExecutedEvent could still arrive is the bug we are fixing.
+	require.NotNil(t, gravityKeeper.GetOutgoingTx(ctx, storeKey),
+		"batch was cancelled before any event was observed past its timeout")
+
+	// Once an event is actually observed past the timeout, cleanup should fire.
+	gravityKeeper.SetLastEventObservedEthereumBlockHeight(ctx, batchTimeout+100)
+	gravity.BeginBlocker(ctx, gravityKeeper)
+	require.Nil(t, gravityKeeper.GetOutgoingTx(ctx, storeKey),
+		"batch should be cancelled once an event is observed past its timeout")
 }
 
 func TestUpdateObservedEthereumHeight(t *testing.T) {

--- a/module/x/gravity/keeper/ethereum_event_vote.go
+++ b/module/x/gravity/keeper/ethereum_event_vote.go
@@ -94,6 +94,10 @@ func (k Keeper) TryEventVoteRecord(ctx sdk.Context, eventVoteRecord *types.Ether
 				}
 				k.setLastObservedEventNonce(ctx, event.GetEventNonce())
 				k.SetLastObservedEthereumBlockHeight(ctx, event.GetEthereumHeight())
+				// Record the event-observed height separately. Cleanup of timed-out
+				// outgoing txs reads this key to ensure that no in-flight
+				// BatchExecutedEvent for the cancelled batch could still arrive.
+				k.SetLastEventObservedEthereumBlockHeight(ctx, event.GetEthereumHeight())
 
 				eventVoteRecord.Accepted = true
 				k.setEthereumEventVoteRecord(ctx, event.GetEventNonce(), event.Hash(), eventVoteRecord)
@@ -252,6 +256,42 @@ func (k Keeper) SetLastObservedEthereumBlockHeightWithCosmos(ctx sdk.Context, et
 		CosmosHeight:   cosmosHeight,
 	}
 	store.Set([]byte{types.LastEthereumBlockHeightKey}, k.cdc.MustMarshal(&height))
+}
+
+// GetLastEventObservedEthereumBlockHeight returns the highest Ethereum block
+// height for which an EthereumEvent has actually been observed and applied via
+// attestation. Unlike GetLastObservedEthereumBlockHeight, this value never
+// advances purely from MsgEthereumHeightVote consensus, so a pending
+// BatchExecutedEvent cannot be silently skipped past by validator height votes.
+func (k Keeper) GetLastEventObservedEthereumBlockHeight(ctx sdk.Context) types.LatestEthereumBlockHeight {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get([]byte{types.LastEventObservedEthereumBlockHeightKey})
+	if len(bz) == 0 {
+		return types.LatestEthereumBlockHeight{}
+	}
+	height := types.LatestEthereumBlockHeight{}
+	k.cdc.MustUnmarshal(bz, &height)
+	return height
+}
+
+// SetLastEventObservedEthereumBlockHeight records the Ethereum height of the
+// most recently observed event. Refuses to roll backwards: events are applied
+// in strict event-nonce order and Ethereum nonces are emitted in block order,
+// so the recorded height must be monotonically non-decreasing.
+func (k Keeper) SetLastEventObservedEthereumBlockHeight(ctx sdk.Context, ethereumHeight uint64) {
+	previous := k.GetLastEventObservedEthereumBlockHeight(ctx)
+	if previous.EthereumHeight > ethereumHeight {
+		panic(fmt.Sprintf(
+			"refusing to roll back last event-observed Ethereum block height: have %d, attempted %d",
+			previous.EthereumHeight, ethereumHeight,
+		))
+	}
+	store := ctx.KVStore(k.storeKey)
+	height := types.LatestEthereumBlockHeight{
+		EthereumHeight: ethereumHeight,
+		CosmosHeight:   uint64(ctx.BlockHeight()),
+	}
+	store.Set([]byte{types.LastEventObservedEthereumBlockHeightKey}, k.cdc.MustMarshal(&height))
 }
 
 // setLastObservedEventNonce sets the latest observed event nonce

--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -870,6 +870,13 @@ func (k Keeper) MigrateGravityContract(ctx sdk.Context, newBridgeAddress string,
 
 	store.Set([]byte{types.LastEthereumBlockHeightKey}, k.cdc.MustMarshal(&height))
 
+	// Clear the event-observed height too. Leaving stale data here would either
+	// (a) silently extend timeout cleanup decisions across a bridge contract
+	// swap with values that no longer reflect the live contract, or (b) trip
+	// the rollback panic in SetLastEventObservedEthereumBlockHeight when the
+	// first event on the new contract is observed at a lower Ethereum height.
+	store.Delete([]byte{types.LastEventObservedEthereumBlockHeightKey})
+
 	k.setLastObservedSignerSetTx(ctx, types.SignerSetTx{
 		Nonce:   0,
 		Height:  0,

--- a/module/x/gravity/keeper/migrations.go
+++ b/module/x/gravity/keeper/migrations.go
@@ -29,6 +29,24 @@ func (m Migrator) MigrateStore(ctx sdk.Context) error {
 	return nil
 }
 
+// MigrateStoreV6ToV7 initializes LastEventObservedEthereumBlockHeight from the
+// existing LastObservedEthereumBlockHeight. At a healthy upgrade boundary the
+// existing value reflects events that have actually been observed (height-vote
+// consensus only advances it past event-observed values, and any pending
+// timeout-cleanup race would have already fired pre-upgrade), so seeding the
+// new key with the same value is safe and preserves cleanup behaviour for
+// outgoing txs created before the upgrade.
+func (m Migrator) MigrateStoreV6ToV7(ctx sdk.Context) error {
+	ctx.Logger().Info("gravity: Initializing LastEventObservedEthereumBlockHeight from LastObservedEthereumBlockHeight")
+	current := m.keeper.GetLastObservedEthereumBlockHeight(ctx)
+	if current.EthereumHeight == 0 {
+		ctx.Logger().Info("gravity: No observed Ethereum height yet; leaving event-observed key unset")
+		return nil
+	}
+	m.keeper.SetLastEventObservedEthereumBlockHeight(ctx, current.EthereumHeight)
+	return nil
+}
+
 // DeletePendingEventVoteRecords deletes pending event vote records and adjusts the last observed nonce for validators
 // who voted on unapproved events. This upgrade includes changes to how event hashes are calculated, so we delete
 // pending event vote records that were created with the old hash calculation method to prevent inconsistent hashes.

--- a/module/x/gravity/keeper/migrations.go
+++ b/module/x/gravity/keeper/migrations.go
@@ -29,21 +29,32 @@ func (m Migrator) MigrateStore(ctx sdk.Context) error {
 	return nil
 }
 
-// MigrateStoreV6ToV7 initializes LastEventObservedEthereumBlockHeight from the
-// existing LastObservedEthereumBlockHeight. At a healthy upgrade boundary the
-// existing value reflects events that have actually been observed (height-vote
-// consensus only advances it past event-observed values, and any pending
-// timeout-cleanup race would have already fired pre-upgrade), so seeding the
-// new key with the same value is safe and preserves cleanup behaviour for
-// outgoing txs created before the upgrade.
+// MigrateStoreV6ToV7 deliberately leaves LastEventObservedEthereumBlockHeight
+// unset (zero) at upgrade time. The pre-upgrade LastObservedEthereumBlockHeight
+// is unsafe to copy because it can be ahead of any event actually applied via
+// attestation: MsgEthereumHeightVote consensus advances it independently of
+// observation, and that decoupling is precisely the source of the race this
+// migration is part of fixing.
+//
+// Two failure modes are avoided by NOT seeding from the old key:
+//
+//  1. Stale-cleanup window. If a BatchExecutedEvent for an executed batch is
+//     pending under the attestation threshold at upgrade time and the old key
+//     has already been pushed past that batch's timeout by height-vote
+//     consensus, seeding the new key with the old value would let the next
+//     BeginBlock cleanup fire on the inflated value and re-trigger the
+//     double-spend the rest of this fix is meant to prevent.
+//  2. Chain-halt. SetLastEventObservedEthereumBlockHeight panics on rollback.
+//     If the new key is seeded ahead of a pending lower-height event, applying
+//     that event after upgrade would attempt a downward write and halt the
+//     chain.
+//
+// Cost of leaving it at zero: cleanup is paused until the first event is
+// applied post-upgrade, after which behaviour is normal. The pre-upgrade
+// LastObservedEthereumBlockHeight is left in place; getTimeoutHeight continues
+// reading it for new-batch timeout projection, which is unaffected by this fix.
 func (m Migrator) MigrateStoreV6ToV7(ctx sdk.Context) error {
-	ctx.Logger().Info("gravity: Initializing LastEventObservedEthereumBlockHeight from LastObservedEthereumBlockHeight")
-	current := m.keeper.GetLastObservedEthereumBlockHeight(ctx)
-	if current.EthereumHeight == 0 {
-		ctx.Logger().Info("gravity: No observed Ethereum height yet; leaving event-observed key unset")
-		return nil
-	}
-	m.keeper.SetLastEventObservedEthereumBlockHeight(ctx, current.EthereumHeight)
+	ctx.Logger().Info("gravity: Leaving LastEventObservedEthereumBlockHeight unset; will advance on next observed event")
 	return nil
 }
 

--- a/module/x/gravity/module.go
+++ b/module/x/gravity/module.go
@@ -135,9 +135,11 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 		panic(fmt.Errorf("failed to register migration handler: %w", err))
 	}
 
-	// The 6 to 7 migration seeds LastEventObservedEthereumBlockHeight from
-	// LastObservedEthereumBlockHeight so that batch/contract-call timeout
-	// cleanup begins reading the new key without a behaviour gap on upgrade.
+	// The 6 to 7 migration deliberately leaves
+	// LastEventObservedEthereumBlockHeight unset rather than seeding it from
+	// LastObservedEthereumBlockHeight, which can be ahead of any attested
+	// event. Timeout cleanup stays paused until the first event is applied
+	// post-upgrade. See MigrateStoreV6ToV7 for why seeding is unsafe.
 	if err := cfg.RegisterMigration(types.ModuleName, 6, func(ctx sdk.Context) error {
 		return migrator.MigrateStoreV6ToV7(ctx)
 	}); err != nil {

--- a/module/x/gravity/module.go
+++ b/module/x/gravity/module.go
@@ -108,7 +108,7 @@ func (AppModule) Name() string {
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
 func (AppModule) ConsensusVersion() uint64 {
-	return 6
+	return 7
 }
 
 // RegisterInvariants implements app module
@@ -131,6 +131,15 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	migrator := keeper.NewMigrator(am.keeper)
 	if err := cfg.RegisterMigration(types.ModuleName, 5, func(ctx sdk.Context) error {
 		return migrator.MigrateStore(ctx)
+	}); err != nil {
+		panic(fmt.Errorf("failed to register migration handler: %w", err))
+	}
+
+	// The 6 to 7 migration seeds LastEventObservedEthereumBlockHeight from
+	// LastObservedEthereumBlockHeight so that batch/contract-call timeout
+	// cleanup begins reading the new key without a behaviour gap on upgrade.
+	if err := cfg.RegisterMigration(types.ModuleName, 6, func(ctx sdk.Context) error {
+		return migrator.MigrateStoreV6ToV7(ctx)
 	}); err != nil {
 		panic(fmt.Errorf("failed to register migration handler: %w", err))
 	}

--- a/module/x/gravity/types/key.go
+++ b/module/x/gravity/types/key.go
@@ -65,6 +65,14 @@ const (
 
 	// CompletedOutgoingTxKey indexes the completed outgoing txs
 	CompletedOutgoingTxKey
+
+	// LastEventObservedEthereumBlockHeightKey indexes the highest Ethereum block
+	// height for which an EthereumEvent has actually been observed and applied
+	// via attestation. Distinct from LastEthereumBlockHeightKey, which can also
+	// advance via MsgEthereumHeightVote consensus without any event being
+	// observed. Used by batch/contract-call timeout cleanup so that a pending
+	// BatchExecutedEvent cannot race against vote-driven height advancement.
+	LastEventObservedEthereumBlockHeightKey
 )
 
 ////////////////////


### PR DESCRIPTION
## Summary

Fixes the bridge double-spend reported as GHSA-4vf2-m5pw-3r3r.

`cleanupTimedOutBatchTxs` and `cleanupTimedOutContractCallTxs` read
`LastObservedEthereumBlockHeight`, which advances through `MsgEthereumHeightVote`
consensus **independently of event attestation**. A `BatchExecutedEvent` for an
already-executed batch can therefore still be pending under the attestation
threshold when cleanup fires. The chain then cancels and re-queues transactions
that have already paid out on Ethereum, enabling either re-execution on Ethereum
(the Solidity contract enforces only last-nonce plus per-batch timeout) or a
refund via `MsgCancelSendToEthereum`.

Reported by Dhruva (sdxdhruva).

## Fix

Introduce `LastEventObservedEthereumBlockHeight`, written **only** by
`TryEventVoteRecord` when an event is actually applied. Timeout cleanup reads
the new key, so it can no longer run ahead of attestation.

`ConsensusVersion` goes 6 -> 7 with a registered store migration.

## Migration is deliberately a no-op

`MigrateStoreV6ToV7` leaves the new key unset rather than seeding it from the
legacy value. Seeding would be unsafe in two ways:

1. **Stale-cleanup window.** If the legacy key has been pushed past a pending
   batch's timeout by height-vote consensus, seeding would let the next
   `BeginBlock` re-trigger the very double-spend this fixes, at the upgrade
   boundary.
2. **Chain halt.** `SetLastEventObservedEthereumBlockHeight` panics on rollback.
   Seeding ahead of a pending lower-height event makes applying that event a
   downward write.

Cost: timeout cleanup pauses until the first event is applied post-upgrade, then
behaves normally. `getTimeoutHeight` still reads the legacy key for new-batch
timeout projection, which this fix does not affect.

`MigrateGravityContract` also clears the new key on a bridge contract swap, so
the new contract's first event cannot panic against a stale carried-over height.

## Tests

`go test ./x/gravity/...` passes. Added:

- coverage that cleanup keys off the attested height rather than the voted one
- `TestMigrateStoreV6ToV7DoesNotSeedTaintedHeight`, asserting the migration does
  not seed from the tainted legacy value, that cleanup does not fire
  post-migration, and that applying a pending event below the legacy value does
  not panic

## Release

Needs to be tagged `module/v6.1.0`; Sommelier v10 bumps to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling for batch transactions and contract calls by relying on confirmed Ethereum events rather than vote-only height updates.
  * Prevented cleanup from advancing prematurely when Ethereum events have not yet reached attestation consensus.
  * Preserved pending lower-height events safely during upgrades and contract migrations.

* **Maintenance**
  * Added a version 6→7 state migration to support the updated timeout tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->